### PR TITLE
Settings center, Gambit send-key, tab/task fixes (2.9.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "coffee-cli"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coffee-cli"
-version = "2.9.1"
+version = "2.9.2"
 edition = "2021"
 description = "Lightweight Multi-layer AI CLI Terminal"
 license = "AGPL-3.0-or-later"

--- a/install/release-notes-template.md
+++ b/install/release-notes-template.md
@@ -1,39 +1,59 @@
 <details open>
 <summary><b>🇨🇳 简体中文</b></summary>
 
-- 新增 6 个可一键启动的 AI CLI：**Pi、Crush、Aider、Kimi Code、Goose、Copilot CLI**。在启动器里直接点开，每个都带品牌图标、目录名标签页和状态指示。
-- 所有 AI CLI 的标签页现在统一显示状态指示灯。
+- 全新设置中心:标题栏齿轮一处集中调整主题配色、壁纸、终端文字色与界面语言,告别挤在侧栏的弹出菜单。
+- 主题选择改为双色预览卡,一眼看清每个主题的背景色与强调色。
+- 「妙手」输入框可自选发送键:默认 Enter 发送、Shift+Enter 换行,也能切换为 Ctrl/⌘+Enter 发送。
+- 设置面板底部显示当前版本号。
+- 修复:切换标签页时偶尔闪现上一帧的残影。
+- 优化:编辑任务标题时长文字自动换行。
 
 </details>
 
 <details>
 <summary><b>🇹🇼 繁體中文</b></summary>
 
-- 新增 6 個可一鍵啟動的 AI CLI：**Pi、Crush、Aider、Kimi Code、Goose、Copilot CLI**。在啟動器裡直接點開，每個都帶品牌圖示、目錄名標籤頁與狀態指示。
-- 所有 AI CLI 的標籤頁現在統一顯示狀態指示燈。
+- 全新設定中心:標題列齒輪一處集中調整主題配色、桌布、終端文字色與介面語言,告別擠在側欄的彈出選單。
+- 主題選擇改為雙色預覽卡,一眼看清每個主題的背景色與強調色。
+- 「妙手」輸入框可自選發送鍵:預設 Enter 發送、Shift+Enter 換行,也能切換為 Ctrl/⌘+Enter 發送。
+- 設定面板底部顯示目前版本號。
+- 修復:切換分頁時偶爾閃現上一幀的殘影。
+- 最佳化:編輯任務標題時長文字自動換行。
 
 </details>
 
 <details>
 <summary><b>🇬🇧 English</b></summary>
 
-- Six new one-click AI CLIs: **Pi, Crush, Aider, Kimi Code, Goose, Copilot CLI** — launch them straight from the launchpad, each with its brand icon, folder-name tab, and status indicator.
-- Every AI CLI tab now shows a status indicator.
+- New settings center: one titlebar gear for theme colors, wallpaper, terminal text color, and interface language — no more menus crammed into the sidebar.
+- Theme picker now uses two-tone preview cards, so you can see each theme's background and accent at a glance.
+- Gambit compose box now lets you choose your send key — Enter to send / Shift+Enter for a newline (default), or Ctrl/⌘+Enter to send.
+- The current version is shown at the bottom of the settings panel.
+- Fixed: a brief ghost of the previous frame when switching tabs.
+- Improved: long task titles now wrap while you're editing them.
 
 </details>
 
 <details>
 <summary><b>🇯🇵 日本語</b></summary>
 
-- ワンクリックで起動できる AI CLI を 6 つ追加：**Pi・Crush・Aider・Kimi Code・Goose・Copilot CLI**。ランチパッドから直接起動でき、それぞれにブランドアイコン・フォルダー名タブ・ステータス表示が付きます。
-- すべての AI CLI のタブにステータスインジケーターが表示されるようになりました。
+- 新しい設定センター:タイトルバーの歯車から、テーマカラー・壁紙・ターミナル文字色・表示言語をまとめて調整。サイドバーに散らばっていたメニューが不要になりました。
+- テーマ選択が二色プレビューカードに。各テーマの背景色とアクセント色がひと目で分かります。
+- 「一手」入力欄で送信キーを選べるように:既定は Enter で送信・Shift+Enter で改行、Ctrl/⌘+Enter での送信にも切り替え可能。
+- 設定パネル下部に現在のバージョンを表示。
+- 修正:タブ切り替え時に前の画面が一瞬残る残像。
+- 改善:タスクのタイトル編集中、長い文字が自動で折り返されます。
 
 </details>
 
 <details>
 <summary><b>🇰🇷 한국어</b></summary>
 
-- 원클릭으로 실행하는 AI CLI 6종 추가: **Pi · Crush · Aider · Kimi Code · Goose · Copilot CLI**. 런치패드에서 바로 실행되며 각각 브랜드 아이콘 · 폴더명 탭 · 상태 표시기를 제공합니다.
-- 모든 AI CLI 탭에 상태 표시기가 표시됩니다.
+- 새로운 설정 센터: 타이틀바 톱니바퀴 하나로 테마 색상 · 배경화면 · 터미널 글자색 · 인터페이스 언어를 한곳에서 조정. 사이드바에 흩어져 있던 메뉴가 사라졌습니다.
+- 테마 선택이 두 가지 색 미리보기 카드로 바뀌어, 각 테마의 배경색과 강조색을 한눈에 볼 수 있습니다.
+- 「한 수」 입력창에서 전송 키를 선택할 수 있습니다: 기본은 Enter 전송 · Shift+Enter 줄바꿈, Ctrl/⌘+Enter 전송으로 전환 가능.
+- 설정 패널 하단에 현재 버전이 표시됩니다.
+- 수정: 탭 전환 시 이전 화면이 잠깐 남는 잔상.
+- 개선: 작업 제목 편집 중 긴 글자가 자동으로 줄바꿈됩니다.
 
 </details>

--- a/src-ui/src/App.tsx
+++ b/src-ui/src/App.tsx
@@ -7,6 +7,7 @@ import { subscribeAgentStatus } from './lib/agent-status-bus';
 import { routeFileDrop } from './lib/file-drop';
 import { TitleBar } from './components/common/TitleBar';
 import { ResizeEdges } from './components/common/ResizeEdges';
+import { SettingsModal } from './components/common/SettingsModal';
 import { Explorer } from './components/left/Explorer';
 import { CenterPanel } from './components/center/CenterPanel';
 import { ActiveGambit } from './components/center/ActiveGambit';
@@ -255,6 +256,11 @@ export function App() {
           status events, etc.) and can be dragged freely across the whole
           app window. Internally reads the active tab's gambit state. */}
       <ActiveGambit />
+
+      {/* Personalization settings — centered modal opened by the titlebar
+          gear. App-level overlay (gated on state.settingsOpen) so it floats
+          above the whole workspace, like ActiveGambit. */}
+      <SettingsModal />
 
       {/* 8 transparent resize-edge strips (window chrome). Three-platform
           unified — Windows + macOS already get edge cursors via OS shims,

--- a/src-ui/src/components/center/Gambit.tsx
+++ b/src-ui/src/components/center/Gambit.tsx
@@ -529,6 +529,10 @@ function GambitImpl({
   const ctxMenuRef = useRef<HTMLDivElement | null>(null);
   const isMac = navigator.platform.toUpperCase().includes('MAC');
   const ctxMod = isMac ? '⌘' : 'Ctrl';
+  // Send/newline key labels for the placeholder hint — track the user's
+  // configured send mode (settings → 妙手) so the hint never lies.
+  const sendCombo = appState.gambitEnterToSend ? 'Enter' : `${ctxMod}+Enter`;
+  const newlineCombo = appState.gambitEnterToSend ? 'Shift+Enter' : 'Enter';
 
   // Windows-style dismiss: ANY interaction outside the menu closes it.
   //   - mousedown anywhere outside  → close (click inside runs the button's onClick)
@@ -668,12 +672,21 @@ function GambitImpl({
       setAttachedSkills(prev => prev.slice(0, -1));
       return;
     }
-    // Ctrl+Enter (or Cmd+Enter on macOS) sends. Plain Enter inserts a newline
-    // — matches office/editor expectation. Shift+Enter also inserts a newline
-    // (native textarea behavior).
-    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
-      e.preventDefault();
-      handleSend();
+    // Send key is user-configurable (settings modal → Keyboard), because the
+    // muscle-memory split (chat-app Enter-to-send vs editor Ctrl+Enter) differs
+    // per person and per OS.
+    //   • enterToSend (default): plain Enter sends; Shift/Ctrl/Cmd+Enter = newline.
+    //   • else:                  Ctrl/Cmd+Enter sends; plain Enter = newline.
+    if (e.key === 'Enter') {
+      const hasMod = e.ctrlKey || e.metaKey;
+      if (appState.gambitEnterToSend) {
+        if (e.shiftKey || hasMod) return; // newline
+        e.preventDefault();
+        handleSend();
+      } else if (hasMod) {
+        e.preventDefault();
+        handleSend();
+      }
     }
   };
 
@@ -906,7 +919,7 @@ function GambitImpl({
           className="gambit-textarea"
           style={{ textIndent: pillsWidth }}
           value={draft}
-          placeholder={attachedSkills.length > 0 ? '' : t('gambit.placeholder')}
+          placeholder={attachedSkills.length > 0 ? '' : t('gambit.placeholder', { send: sendCombo, newline: newlineCombo })}
           onChange={(e) => onDraftChange(e.target.value)}
           onKeyDown={onKeyDown}
           onPaste={onPaste}

--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -8,7 +8,7 @@
 // unrelated global state changes (agent status, other tabs' folder changes,
 // etc.) don't cascade into this component.
 
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
@@ -315,6 +315,17 @@ function TierTerminalImpl({
   // scanner in `onData` below for the consume/advance logic.
   const markerScanBufRef = useRef<string>('');
   const markerScanOffsetRef = useRef<number>(0);
+
+  // ── Stale-frame ghost suppression on tab switch (issue #47) ──────────────
+  // Inactive tabs are display:none (CenterPanel). While hidden, xterm's WebGL
+  // canvas keeps its LAST drawn framebuffer. On switch-back the browser
+  // composites that stale frame, and xterm's redraw is deferred to rAF (the
+  // activation effect below even waits a double-rAF before fit()), so for
+  // 1-2 frames the user sees the *previous* agent UI ghosted in before it
+  // snaps to current. We mask the canvas the instant the tab re-activates
+  // (pre-paint, via useLayoutEffect) so the solid terminal background shows
+  // through instead, then unmask once xterm paints its first fresh frame.
+  const [canvasHidden, setCanvasHidden] = useState(false);
 
   // ── Terminal context menu ────────────────────────────────────────────────
   const [ctxMenu, setCtxMenu] = useState<CtxMenu | null>(null);
@@ -1051,22 +1062,59 @@ function TierTerminalImpl({
   // When this session becomes the active tab, refit + focus after layout.
   // Uses double-rAF instead of a 150ms setTimeout so perceived switch latency
   // drops from 150ms to ~32ms (two frames).
-  useEffect(() => {
+  //
+  // useLayoutEffect (not useEffect) so the mask below is committed BEFORE the
+  // browser paints the now-visible tab — useEffect runs post-paint, which is
+  // exactly when the stale WebGL frame would flash through (issue #47). We
+  // only mask when xterm already exists (a real switch-back, not first mount,
+  // where the splash covers init and there is no stale frame yet).
+  useLayoutEffect(() => {
     if (!isActive) return;
+    if (xtermRef.current) setCanvasHidden(true);
+
     let f1 = 0, f2 = 0;
+    let revealed = false;
+    let renderSub: { dispose: () => void } | null = null;
+    const reveal = () => {
+      if (revealed) return;
+      revealed = true;
+      renderSub?.dispose();
+      renderSub = null;
+      setCanvasHidden(false);
+    };
+
     f1 = requestAnimationFrame(() => {
       f2 = requestAnimationFrame(() => {
-        fitRef.current?.fit();
+        // fit() can throw if the container is momentarily zero-size during a
+        // layout race — guard it (same as the ResizeObserver path) so a throw
+        // never skips the onRender subscription + resize IPC below and strand
+        // the resize. reveal() is still backstopped by the fallback regardless.
+        try { fitRef.current?.fit(); } catch {}
         xtermRef.current?.focus();
         const term = xtermRef.current;
-        if (!term || term.cols <= 0 || term.rows <= 0) return;
+        if (!term || term.cols <= 0 || term.rows <= 0) { reveal(); return; }
+        // Force a redraw of the current buffer, then unmask on the first real
+        // frame xterm draws — guarantees the fresh content is on the canvas
+        // before we reveal it.
+        renderSub = term.onRender(() => reveal());
+        term.refresh(0, term.rows - 1);
         const prev = lastResizeRef.current;
-        if (prev && prev.cols === term.cols && prev.rows === term.rows) return;
-        lastResizeRef.current = { cols: term.cols, rows: term.rows };
-        commands.tierTerminalResize(sessionId, term.cols, term.rows).catch(() => {});
+        if (!prev || prev.cols !== term.cols || prev.rows !== term.rows) {
+          lastResizeRef.current = { cols: term.cols, rows: term.rows };
+          commands.tierTerminalResize(sessionId, term.cols, term.rows).catch(() => {});
+        }
       });
     });
-    return () => { cancelAnimationFrame(f1); cancelAnimationFrame(f2); };
+
+    // Safety net: never strand the canvas masked if onRender doesn't fire.
+    const fallback = setTimeout(reveal, 150);
+    return () => {
+      cancelAnimationFrame(f1);
+      cancelAnimationFrame(f2);
+      clearTimeout(fallback);
+      renderSub?.dispose();
+      revealed = true;
+    };
   }, [isActive, sessionId]);
 
   // ── Startup splash dismissal ────────────────────────────────────────────
@@ -1179,6 +1227,12 @@ function TierTerminalImpl({
       <div
         ref={wrapRef}
         className="tier-xterm-wrap"
+        // Hidden for the 1-2 frames after a tab switch-back so the stale WebGL
+        // framebuffer never flashes; the backdrop behind the wrap shows through
+        // until xterm repaints — solid theme bg (opaque), the wallpaper layer
+        // (hasBg), or the glass tint (transparent themes), whichever applies.
+        // See the activation effect above (issue #47).
+        style={canvasHidden ? { opacity: 0 } : undefined}
         onContextMenu={(e) => {
           e.preventDefault();
           e.stopPropagation();

--- a/src-ui/src/components/common/SettingsModal.css
+++ b/src-ui/src/components/common/SettingsModal.css
@@ -1,0 +1,346 @@
+/* SettingsModal.css — centered personalization modal (titlebar gear). */
+
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  animation: settings-fade 0.16s ease;
+}
+
+@keyframes settings-fade { from { opacity: 0; } to { opacity: 1; } }
+
+.settings-modal {
+  display: flex;
+  width: min(720px, 92vw);
+  height: min(540px, 86vh);
+  background: var(--bg-panel, #1c1c1e);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  border-radius: var(--radius-md, 14px);
+  box-shadow: 0 24px 60px -12px rgba(0, 0, 0, 0.55), 0 8px 20px -8px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+  animation: settings-pop 0.18s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@keyframes settings-pop {
+  from { opacity: 0; transform: scale(0.97) translateY(6px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* ── Left rail ─────────────────────────────────────────────────────────── */
+.settings-rail {
+  flex: 0 0 168px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 16px 10px;
+  background: color-mix(in srgb, var(--bg-app, #161618) 55%, transparent);
+  border-right: 1px solid var(--border, rgba(255, 255, 255, 0.06));
+}
+
+.settings-rail-title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-3, rgba(255, 255, 255, 0.4));
+  padding: 4px 12px 12px;
+}
+
+.settings-rail-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  text-align: left;
+  padding: 9px 12px;
+  border: none;
+  background: transparent;
+  color: var(--text-2, rgba(255, 255, 255, 0.7));
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: var(--radius-sm, 8px);
+  cursor: pointer;
+  transition: background 0.14s ease, color 0.14s ease;
+}
+.settings-rail-item:hover { background: var(--bg-hover, rgba(255, 255, 255, 0.05)); }
+.settings-rail-item.active {
+  background: color-mix(in srgb, var(--accent, #c4956a) 16%, transparent);
+  color: var(--text-1, #fff);
+}
+.settings-rail-icon { display: flex; opacity: 0.85; }
+.settings-rail-icon svg { width: 16px; height: 16px; }
+
+/* App version pinned to the bottom of the rail. */
+.settings-rail-version {
+  margin-top: auto;
+  padding: 10px 12px 4px;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  color: var(--text-3, rgba(255, 255, 255, 0.35));
+}
+
+/* ── Content (fixed header + scrolling body) ───────────────────────────── */
+.settings-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  padding: 15px 18px;
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.07));
+}
+.settings-header-title { font-size: 15px; font-weight: 600; color: var(--text-1, #fff); }
+
+.settings-close {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--text-3, rgba(255, 255, 255, 0.4));
+  border-radius: var(--radius-sm, 8px);
+  cursor: pointer;
+  transition: background 0.14s ease, color 0.14s ease;
+}
+.settings-close:hover { background: var(--bg-hover, rgba(255, 255, 255, 0.06)); color: var(--text-1, #fff); }
+.settings-close svg { width: 16px; height: 16px; }
+
+.settings-body { flex: 1; overflow-y: auto; padding: 18px 18px 24px; }
+
+.settings-section-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-3, rgba(255, 255, 255, 0.4));
+  margin: 20px 0 11px;
+}
+.settings-section-label:first-child { margin-top: 0; }
+
+/* ── Two-tone theme cards (surface band + accent band, label below) ────── */
+.settings-theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(76px, 1fr));
+  gap: 11px;
+}
+.settings-theme-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+.settings-theme-preview {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 46px;
+  border-radius: var(--radius-sm, 9px);
+  overflow: hidden;
+  border: 2px solid transparent;
+  transition: border-color 0.14s ease, transform 0.14s ease;
+}
+.settings-theme-card:hover .settings-theme-preview { transform: translateY(-1px); }
+.settings-theme-card.active .settings-theme-preview { border-color: var(--ring, var(--accent)); }
+.settings-theme-band-bg { flex: 1; }
+.settings-theme-band-accent { height: 14px; }
+.settings-theme-check {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.settings-theme-check svg { width: 9px; height: 9px; }
+.settings-theme-name {
+  font-size: 11px;
+  text-align: center;
+  color: var(--text-2, rgba(255, 255, 255, 0.7));
+  transition: color 0.14s ease;
+}
+.settings-theme-card.active .settings-theme-name { color: var(--text-1, #fff); }
+
+/* ── Chips (shape / generic) ───────────────────────────────────────────── */
+.settings-chip-row { display: flex; flex-wrap: wrap; gap: 8px; }
+.settings-chip {
+  padding: 7px 14px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: transparent;
+  color: var(--text-2, rgba(255, 255, 255, 0.7));
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: var(--radius-sm, 8px);
+  cursor: pointer;
+  transition: all 0.14s ease;
+}
+.settings-chip:hover { background: var(--bg-hover, rgba(255, 255, 255, 0.05)); }
+.settings-chip.active {
+  border-color: var(--accent, #c4956a);
+  background: color-mix(in srgb, var(--accent, #c4956a) 16%, transparent);
+  color: var(--text-1, #fff);
+}
+
+/* ── Icon-theme chips ──────────────────────────────────────────────────── */
+.settings-icon-row { gap: 6px; }
+.settings-icon-chip {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: transparent;
+  border-radius: var(--radius-sm, 8px);
+  cursor: pointer;
+  transition: all 0.14s ease;
+}
+.settings-icon-chip:hover { background: var(--bg-hover, rgba(255, 255, 255, 0.05)); }
+.settings-icon-chip.active {
+  border-color: var(--accent, #c4956a);
+  background: color-mix(in srgb, var(--accent, #c4956a) 16%, transparent);
+}
+.settings-icon-mask {
+  width: 24px;
+  height: 24px;
+  background-color: var(--accent, #c4956a);
+  -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
+  -webkit-mask-position: center; mask-position: center;
+  -webkit-mask-size: contain; mask-size: contain;
+}
+
+/* ── Wallpaper ─────────────────────────────────────────────────────────── */
+.settings-wallpaper-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.settings-btn {
+  padding: 8px 16px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  background: var(--bg-hover, rgba(255, 255, 255, 0.05));
+  color: var(--text-1, #fff);
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: var(--radius-sm, 8px);
+  cursor: pointer;
+  transition: all 0.14s ease;
+}
+.settings-btn:hover { border-color: var(--accent, #c4956a); }
+.settings-btn-danger { color: #e06666; }
+.settings-btn-danger:hover { border-color: #e06666; }
+
+.settings-slider-row { display: flex; align-items: center; gap: 12px; }
+.settings-slider { flex: 1; accent-color: var(--accent, #c4956a); cursor: pointer; }
+.settings-slider:disabled { opacity: 0.4; cursor: not-allowed; }
+.settings-slider-value {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-2, rgba(255, 255, 255, 0.7));
+  min-width: 38px;
+  text-align: right;
+}
+
+/* ── Terminal text-colour chips ────────────────────────────────────────── */
+.settings-term-chip {
+  width: 36px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 700;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: transparent;
+  border-radius: var(--radius-sm, 8px);
+  cursor: pointer;
+  transition: all 0.14s ease;
+}
+.settings-term-chip.reset { color: var(--text-2, rgba(255, 255, 255, 0.7)); }
+.settings-term-chip:hover { background: var(--bg-hover, rgba(255, 255, 255, 0.05)); }
+.settings-term-chip.active { border-color: var(--accent, #c4956a); background: color-mix(in srgb, var(--accent, #c4956a) 14%, transparent); }
+
+/* ── Keyboard: send-key cards ──────────────────────────────────────────── */
+.settings-key-row { display: flex; gap: 10px; flex-wrap: wrap; }
+.settings-key-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 160px;
+  padding: 14px 16px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: transparent;
+  border-radius: var(--radius-sm, 10px);
+  cursor: pointer;
+  transition: all 0.14s ease;
+}
+.settings-key-card:hover { background: var(--bg-hover, rgba(255, 255, 255, 0.04)); }
+.settings-key-card.active {
+  border-color: var(--accent, #c4956a);
+  background: color-mix(in srgb, var(--accent, #c4956a) 12%, transparent);
+}
+.settings-key-combo { display: flex; align-items: center; gap: 5px; }
+.settings-key-plus { color: var(--text-3, rgba(255, 255, 255, 0.4)); font-size: 12px; }
+.settings-key-card kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 24px;
+  padding: 0 8px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-1, #fff);
+  background: var(--bg-hover, rgba(255, 255, 255, 0.06));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  border-radius: var(--radius-xs, 6px);
+}
+.settings-key-card.active kbd { border-color: color-mix(in srgb, var(--accent, #c4956a) 50%, transparent); }
+.settings-key-sub { font-size: 11px; color: var(--text-3, rgba(255, 255, 255, 0.45)); }
+
+/* ── Language list ─────────────────────────────────────────────────────── */
+.settings-lang-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 6px;
+}
+.settings-lang-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-2, rgba(255, 255, 255, 0.7));
+  font-size: 13px;
+  border-radius: var(--radius-sm, 8px);
+  cursor: pointer;
+  transition: all 0.14s ease;
+}
+.settings-lang-item:hover { background: var(--bg-hover, rgba(255, 255, 255, 0.05)); }
+.settings-lang-item.active {
+  border-color: var(--accent, #c4956a);
+  background: color-mix(in srgb, var(--accent, #c4956a) 14%, transparent);
+  color: var(--text-1, #fff);
+}
+.settings-lang-glyph { width: 22px; text-align: center; font-size: 15px; flex-shrink: 0; }
+.settings-lang-label { flex: 1; }
+.settings-lang-check { display: flex; color: var(--accent, #c4956a); }
+.settings-lang-check svg { width: 14px; height: 14px; }

--- a/src-ui/src/components/common/SettingsModal.tsx
+++ b/src-ui/src/components/common/SettingsModal.tsx
@@ -1,0 +1,341 @@
+// SettingsModal.tsx — centered personalization modal opened by the titlebar
+// gear. Consolidates what used to be two overloaded left-panel popovers (the
+// theme menu's color/shape/icon/wallpaper/terminal controls + the language
+// dropdown) into one sectioned surface. Gambit is deliberately NOT here — it's
+// a compose action, not a setting, and keeps its own left-cluster button.
+//
+// Layout: an icon rail (left) + a content column whose header (section title +
+// close) is fixed while the body scrolls, so a long list (language) can never
+// slide under the close button. Theme colours render as two-tone preview cards
+// (surface band + accent band) with the label BELOW the swatch, never on it.
+//
+// Dispatch + persistence mirror the former Explorer wiring exactly so behaviour
+// is unchanged; only the presentation moved.
+
+import { useEffect, useState, type ReactNode } from 'react';
+import { useAppState, useAppDispatch, type ThemeColor, type ThemeShape, type IconTheme } from '../../store/app-state';
+import { useT } from '../../i18n/useT';
+import { IS_MACOS } from '../../lib/platform';
+import { TERM_COLOR_SCHEMES } from '../center/TierTerminal';
+import { THEME_COLORS, THEME_SHAPES, ICON_ART_THEMES, LANGUAGES, isMaskTintTheme } from '../../lib/personalization';
+import './SettingsModal.css';
+
+type Section = 'appearance' | 'wallpaper' | 'terminal' | 'gambit' | 'language';
+
+const ICONS: Record<Section, ReactNode> = {
+  appearance: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" /><circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+      <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" /><circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+      <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.563-2.512 5.563-5.563C21.5 6.012 17.262 2 12 2z" />
+    </svg>
+  ),
+  wallpaper: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+    </svg>
+  ),
+  terminal: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="m7 11 2-2-2-2" /><path d="M11 13h4" /><rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+    </svg>
+  ),
+  gambit: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <rect width="20" height="16" x="2" y="4" rx="2" />
+      <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10" />
+    </svg>
+  ),
+  language: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" /><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" /><path d="M2 12h20" />
+    </svg>
+  ),
+};
+
+export function SettingsModal() {
+  const { state } = useAppState();
+  const dispatch = useAppDispatch();
+  const t = useT();
+  const [section, setSection] = useState<Section>('appearance');
+  const [version, setVersion] = useState('');
+
+  const open = state.settingsOpen;
+  const close = () => dispatch({ type: 'SET_SETTINGS_OPEN', open: false });
+
+  // App version for the rail footer — pulled from the Tauri runtime (matches
+  // tauri.conf.json) once, lazily so non-Tauri dev just shows nothing.
+  useEffect(() => {
+    let cancelled = false;
+    import('@tauri-apps/api/app')
+      .then(({ getVersion }) => getVersion())
+      .then(v => { if (!cancelled) setVersion(v); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') close(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  if (!open) return null;
+
+  // ── Handlers (identical to the former left-panel ThemeMenu/Lang wiring) ──
+  const setTheme = (th: ThemeColor) => dispatch({ type: 'SET_THEME', theme: th });
+  const setShape = (s: ThemeShape) => dispatch({ type: 'SET_SHAPE', shape: s });
+  const setIconTheme = (th: IconTheme) => {
+    dispatch({ type: 'SET_ICON_THEME', theme: th });
+    try { localStorage.setItem('cc-icon-theme', th); } catch {}
+  };
+  const setLang = (code: string) => {
+    dispatch({ type: 'SET_LANG', lang: code });
+    try {
+      localStorage.setItem('cc-lang', code);
+      if (code !== 'en') localStorage.setItem('cc-native-lang', code);
+    } catch {}
+  };
+  const pickBg = async () => {
+    try {
+      const { open: openDialog } = await import('@tauri-apps/plugin-dialog');
+      const selected = await openDialog({
+        filters: [{ name: 'Background', extensions: ['jpg', 'jpeg', 'png', 'gif', 'webp', 'mp4', 'webm'] }],
+      });
+      if (selected && typeof selected === 'string') {
+        const ext = selected.split('.').pop()?.toLowerCase() || '';
+        const bgType = ['mp4', 'webm'].includes(ext) ? 'video' : 'image';
+        try { localStorage.setItem('cc-bg-path', selected); localStorage.setItem('cc-bg-type', bgType); } catch {}
+        dispatch({ type: 'SET_BG', path: selected, bgType });
+      }
+    } catch (err) { console.error('[Settings] background picker failed:', err); }
+  };
+  const clearBg = () => {
+    try { localStorage.removeItem('cc-bg-path'); localStorage.removeItem('cc-bg-type'); } catch {}
+    dispatch({ type: 'CLEAR_BG' });
+  };
+  const setScheme = (id: string) => {
+    try { id ? localStorage.setItem('cc-term-scheme', id) : localStorage.removeItem('cc-term-scheme'); } catch {}
+    dispatch({ type: 'SET_TERM_SCHEME', scheme: id });
+  };
+  const setOpacity = (n: number) => dispatch({ type: 'SET_WALLPAPER_OPACITY', opacity: n });
+  const setEnterToSend = (value: boolean) => {
+    dispatch({ type: 'SET_GAMBIT_ENTER_TO_SEND', value });
+    try { localStorage.setItem('cc-gambit-enter-send', String(value)); } catch {}
+  };
+
+  const hasBg = state.bgType !== 'none' && state.bgPath !== '';
+  const modKey = IS_MACOS ? '⌘' : 'Ctrl';
+
+  const SECTIONS: { id: Section; label: string }[] = [
+    { id: 'appearance', label: t('settings.appearance' as any) },
+    { id: 'wallpaper',  label: t('settings.wallpaper' as any) },
+    { id: 'terminal',   label: t('settings.terminal' as any) },
+    { id: 'gambit',     label: t('settings.gambit' as any) },
+    { id: 'language',   label: t('settings.language' as any) },
+  ];
+  const currentLabel = SECTIONS.find(s => s.id === section)?.label ?? '';
+
+  return (
+    <div className="settings-overlay" onMouseDown={close}>
+      <div
+        className="settings-modal"
+        onMouseDown={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        <aside className="settings-rail">
+          <div className="settings-rail-title">{t('settings.title' as any)}</div>
+          {SECTIONS.map(s => (
+            <button
+              key={s.id}
+              className={`settings-rail-item${section === s.id ? ' active' : ''}`}
+              onClick={() => setSection(s.id)}
+            >
+              <span className="settings-rail-icon">{ICONS[s.id]}</span>
+              {s.label}
+            </button>
+          ))}
+          {version && <div className="settings-rail-version">v{version}</div>}
+        </aside>
+
+        <section className="settings-content">
+          <header className="settings-header">
+            <span className="settings-header-title">{currentLabel}</span>
+            <button className="settings-close" onClick={close} aria-label="Close">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+              </svg>
+            </button>
+          </header>
+
+          <div className="settings-body">
+            {section === 'appearance' && (
+              <>
+                <div className="settings-section-label">{t('theme.section.color')}</div>
+                <div className="settings-theme-grid">
+                  {THEME_COLORS.map(c => {
+                    const active = c.code === state.currentTheme;
+                    return (
+                      <button
+                        key={c.code}
+                        className={`settings-theme-card${active ? ' active' : ''}`}
+                        onClick={() => setTheme(c.code)}
+                        aria-pressed={active}
+                      >
+                        <span className="settings-theme-preview" style={{ ['--ring' as any]: c.ring }}>
+                          <span className="settings-theme-band-bg" style={{ background: c.swatch }} />
+                          <span className="settings-theme-band-accent" style={{ background: c.ring }} />
+                          {active && (
+                            <span className="settings-theme-check" style={{ background: c.ring }}>
+                              <svg viewBox="0 0 24 24" fill="none" stroke="#000" strokeWidth="3.5" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+                            </span>
+                          )}
+                        </span>
+                        <span className="settings-theme-name">{t(c.labelKey as any)}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <div className="settings-section-label">{t('theme.section.shape')}</div>
+                <div className="settings-chip-row">
+                  {THEME_SHAPES.map(s => (
+                    <button
+                      key={s.code}
+                      className={`settings-chip${s.code === state.currentShape ? ' active' : ''}`}
+                      onClick={() => setShape(s.code)}
+                    >
+                      {s.label}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="settings-section-label">{t('theme.section.icons')}</div>
+                <div className="settings-chip-row settings-icon-row">
+                  {ICON_ART_THEMES.map(({ id, folderSrc }) => (
+                    <button
+                      key={id}
+                      className={`settings-icon-chip${state.iconTheme === id ? ' active' : ''}`}
+                      onClick={() => setIconTheme(id)}
+                    >
+                      {isMaskTintTheme(id) ? (
+                        <span
+                          className="settings-icon-mask"
+                          style={{ WebkitMaskImage: `url("${folderSrc}")`, maskImage: `url("${folderSrc}")` }}
+                          aria-label={id}
+                        />
+                      ) : (
+                        <img src={folderSrc} alt={id} width="24" height="24" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
+
+            {section === 'wallpaper' && (
+              <>
+                <div className="settings-section-label">{t('settings.wallpaper' as any)}</div>
+                <div className="settings-wallpaper-actions">
+                  <button className="settings-btn" onClick={pickBg}>{t('settings.wallpaper.pick' as any)}</button>
+                  {hasBg && (
+                    <button className="settings-btn settings-btn-danger" onClick={clearBg}>
+                      {t('settings.wallpaper.clear' as any)}
+                    </button>
+                  )}
+                </div>
+
+                <div className="settings-section-label">{t('settings.wallpaper.opacity' as any)}</div>
+                <div className="settings-slider-row">
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={5}
+                    value={state.wallpaperOpacity}
+                    onChange={e => setOpacity(parseInt(e.target.value, 10))}
+                    className="settings-slider"
+                    disabled={!hasBg}
+                    aria-label="Wallpaper opacity"
+                  />
+                  <span className="settings-slider-value">{state.wallpaperOpacity}%</span>
+                </div>
+              </>
+            )}
+
+            {section === 'terminal' && (
+              <>
+                <div className="settings-section-label">{t('settings.terminal.scheme' as any)}</div>
+                <div className="settings-chip-row">
+                  <button
+                    className={`settings-term-chip reset${state.termColorScheme === '' ? ' active' : ''}`}
+                    onClick={() => setScheme('')}
+                  >
+                    Aa
+                  </button>
+                  {TERM_COLOR_SCHEMES.map(s => (
+                    <button
+                      key={s.id}
+                      className={`settings-term-chip${state.termColorScheme === s.id ? ' active' : ''}`}
+                      style={{ color: s.fg }}
+                      onClick={() => setScheme(state.termColorScheme === s.id ? '' : s.id)}
+                    >
+                      Aa
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
+
+            {section === 'gambit' && (
+              <>
+                <div className="settings-section-label">{t('settings.send.title' as any)}</div>
+                <div className="settings-key-row">
+                  <button
+                    className={`settings-key-card${state.gambitEnterToSend ? ' active' : ''}`}
+                    onClick={() => setEnterToSend(true)}
+                    aria-pressed={state.gambitEnterToSend}
+                  >
+                    <span className="settings-key-combo"><kbd>Enter</kbd></span>
+                    <span className="settings-key-sub">Shift+Enter {t('settings.send.newline' as any)}</span>
+                  </button>
+                  <button
+                    className={`settings-key-card${!state.gambitEnterToSend ? ' active' : ''}`}
+                    onClick={() => setEnterToSend(false)}
+                    aria-pressed={!state.gambitEnterToSend}
+                  >
+                    <span className="settings-key-combo"><kbd>{modKey}</kbd><span className="settings-key-plus">+</span><kbd>Enter</kbd></span>
+                    <span className="settings-key-sub">Enter {t('settings.send.newline' as any)}</span>
+                  </button>
+                </div>
+              </>
+            )}
+
+            {section === 'language' && (
+              <div className="settings-lang-list">
+                {LANGUAGES.map(lang => (
+                  <button
+                    key={lang.code}
+                    className={`settings-lang-item${lang.code === state.currentLang ? ' active' : ''}`}
+                    onClick={() => setLang(lang.code)}
+                  >
+                    <span className="settings-lang-glyph">{lang.glyph}</span>
+                    <span className="settings-lang-label">{lang.label}</span>
+                    {lang.code === state.currentLang && (
+                      <span className="settings-lang-check">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src-ui/src/components/common/TitleBar.tsx
+++ b/src-ui/src/components/common/TitleBar.tsx
@@ -133,6 +133,20 @@ export function TitleBar() {
             <line x1="15" y1="4" x2="15" y2="20" />
           </svg>
         </button>
+
+        {/* Personalization settings — gear opens the consolidated modal that
+            replaced the old left-panel theme/language popovers. */}
+        <button
+          className={`titlebar-btn titlebar-btn--layout${state.settingsOpen ? ' is-active' : ''}`}
+          onClick={() => dispatch({ type: 'TOGGLE_SETTINGS' })}
+          aria-label="Settings"
+          aria-pressed={state.settingsOpen}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+        </button>
       </div>
 
       {/* Custom min/max/close — Windows/Linux only. On macOS the OS draws the

--- a/src-ui/src/components/left/Explorer.tsx
+++ b/src-ui/src/components/left/Explorer.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { useAppState } from '../../store/app-state';
-import type { ThemeColor, ThemeShape, IconTheme, ToolType } from '../../store/app-state';
+import type { IconTheme, ToolType } from '../../store/app-state';
 import { useT } from '../../i18n/useT';
+import { isMaskTintTheme } from '../../lib/personalization';
 import { ScrollPanel } from '../common/ScrollPanel';
 import { clipboardWrite } from '../../lib/clipboard';
 import { beginExplorerDrag } from '../../lib/explorer-drag';
@@ -252,263 +253,6 @@ export function ContextMenu({ menu, onClose }: { menu: CtxMenuState; onClose: ()
   );
 }
 
-// ─── Language Dropdown ───────────────────────────────────────────────────────
-
-const LANGUAGES = [
-  { code: 'en',    label: 'English',    glyph: 'A'  },
-  { code: 'zh-CN', label: '简体中文',   glyph: '文' },
-  { code: 'zh-TW', label: '繁體中文',   glyph: '文' },
-  { code: 'ja',    label: '日本語',     glyph: 'あ' },
-  { code: 'ko',    label: '한국어',     glyph: '가' },
-  { code: 'es',    label: 'Español',    glyph: 'Ñ'  },
-  { code: 'fr',    label: 'Français',   glyph: 'Fr' },
-  { code: 'de',    label: 'Deutsch',    glyph: 'De' },
-  { code: 'pt',    label: 'Português',  glyph: 'Pt' },
-  { code: 'ru',    label: 'Русский',    glyph: 'Я'  },
-  { code: 'vi',    label: 'Tiếng Việt', glyph: 'Vi' },
-];
-
-function getLangGlyph(code: string): string {
-  return LANGUAGES.find(l => l.code === code)?.glyph || 'A';
-}
-
-function LangDropdown({ anchorRef, currentLang, onSelect, onClose }: {
-  anchorRef: React.RefObject<HTMLButtonElement | null>;
-  currentLang: string;
-  onSelect: (code: string) => void;
-  onClose: () => void;
-}) {
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const close = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose();
-    };
-    const closeKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    document.addEventListener('mousedown', close);
-    document.addEventListener('keydown', closeKey);
-    return () => {
-      document.removeEventListener('mousedown', close);
-      document.removeEventListener('keydown', closeKey);
-    };
-  }, [onClose]);
-
-  // Position below the anchor button
-  const rect = anchorRef.current?.getBoundingClientRect();
-  const style: React.CSSProperties = {
-    position: 'fixed',
-    top: rect ? rect.bottom + 4 : 0,
-    left: rect ? rect.left : 0,
-    minWidth: 160,
-  };
-
-  return createPortal(
-    <div className="ctx-menu lang-dropdown" ref={menuRef} style={style}>
-      {LANGUAGES.map(lang => (
-        <button
-          key={lang.code}
-          className={`ctx-menu-item ${lang.code === currentLang ? 'lang-active' : ''}`}
-          onClick={() => onSelect(lang.code)}
-        >
-          <span style={{ fontSize: 14, width: 20, textAlign: 'center', flexShrink: 0 }}>{lang.glyph}</span>
-          <span style={{ flex: 1 }}>{lang.label}</span>
-          {lang.code === currentLang && <span style={{ fontSize: 12, opacity: 0.7 }}>✓</span>}
-        </button>
-      ))}
-    </div>,
-    document.body
-  );
-}
-
-// ─── Theme Menu (color × shape) ──────────────────────────────────────────────
-
-const THEME_COLORS: { code: ThemeColor; labelKey: string; swatch: string; ring: string }[] = [
-  { code: 'light',      labelKey: 'theme.color.light',      swatch: '#FAFAF7', ring: '#c4956a' },
-  { code: 'dark',       labelKey: 'theme.color.dark',       swatch: '#1a1917', ring: '#c4956a' },
-  { code: 'cappuccino', labelKey: 'theme.color.cappuccino', swatch: '#1a1a1a', ring: '#4a4a4a' },
-  { code: 'sakura',     labelKey: 'theme.color.sakura',     swatch: '#221b28', ring: '#f8b4c8' },
-  { code: 'lavender',   labelKey: 'theme.color.lavender',   swatch: '#221f2e', ring: '#c8b6ff' },
-  { code: 'mint',       labelKey: 'theme.color.mint',       swatch: '#142623', ring: '#7ae8c8' },
-  // Natural-material palette — independent of shape and terminal font color.
-  // All three intentionally land darker than the existing "dark"/"cappuccino"
-  // themes so they read as "near-black with a faint hue", not "colored theme".
-  { code: 'obsidian',   labelKey: 'theme.color.obsidian',   swatch: '#0a0a0a', ring: '#5a5a5a' },
-  { code: 'cobalt',     labelKey: 'theme.color.cobalt',     swatch: '#0a1020', ring: '#5a85b8' },
-  { code: 'moss',       labelKey: 'theme.color.moss',       swatch: '#0b1612', ring: '#6a9878' },
-  // Vibrant batch — tinted-dark base (swatch = --bg-app) with a saturated
-  // accent ring. Reads colourful next to the muted set above. Crimson is the
-  // Spider-Man hero (pairs with the carbon shape).
-  { code: 'crimson',    labelKey: 'theme.color.crimson',    swatch: '#2a0d10', ring: '#e23b42' },
-  { code: 'sunset',     labelKey: 'theme.color.sunset',     swatch: '#241408', ring: '#f5803b' },
-  { code: 'amber',      labelKey: 'theme.color.amber',      swatch: '#20180a', ring: '#e8a72c' },
-  { code: 'emerald',    labelKey: 'theme.color.emerald',    swatch: '#0a1c12', ring: '#24c281' },
-  { code: 'teal',       labelKey: 'theme.color.teal',       swatch: '#0a2125', ring: '#2bc4c4' },
-  { code: 'indigo',     labelKey: 'theme.color.indigo',     swatch: '#12142e', ring: '#6172f0' },
-  { code: 'fuchsia',    labelKey: 'theme.color.fuchsia',    swatch: '#210f1d', ring: '#d94aa0' },
-];
-
-const THEME_SHAPES: { code: ThemeShape; label: string }[] = [
-  { code: 'soft',  label: 'Soft'  },
-  { code: 'slab',  label: 'Slab'  },
-  { code: 'sharp', label: 'Sharp' },
-  { code: 'glass', label: 'Glass' },
-  { code: 'panel', label: 'Panel' },
-  { code: 'carbon', label: 'Carbon' },
-];
-
-import { TERM_COLOR_SCHEMES } from '../center/TierTerminal';
-
-const ICON_ART_THEMES: { id: IconTheme; folderSrc: string }[] = [
-  { id: 'outline',      folderSrc: '/icons/themes/outline/folder-closed.svg'      },
-  { id: 'material',     folderSrc: '/icons/themes/material/folder-closed.svg'     },
-  { id: 'vscode-icons', folderSrc: '/icons/themes/vscode-icons/folder-closed.svg' },
-  { id: 'catppuccin-mocha', folderSrc: '/icons/themes/catppuccin-mocha/folder-closed.svg' },
-  { id: 'devicon',      folderSrc: '/icons/themes/devicon/folder-closed.svg'      },
-  { id: 'fluent',       folderSrc: '/icons/themes/fluent/folder-closed.svg'       },
-  { id: 'symbols',      folderSrc: '/icons/themes/symbols/folder-closed.svg'      },
-  { id: 'coffee',       folderSrc: '/icons/themes/coffee/folder-closed.svg'       },
-];
-
-function ThemeMenu({ anchorRef, currentTheme, currentShape, currentIconTheme, hasBg, termColorScheme, wallpaperOpacity, onSelectTheme, onSelectShape, onSelectIconTheme, onPickBg, onClearBg, onSelectScheme, onSetWallpaperOpacity, onClose, t }: {
-  anchorRef: React.RefObject<HTMLButtonElement | null>;
-  currentTheme: ThemeColor;
-  currentShape: ThemeShape;
-  currentIconTheme: IconTheme;
-  hasBg: boolean;
-  termColorScheme: string;
-  wallpaperOpacity: number;
-  onSelectTheme: (t: ThemeColor) => void;
-  onSelectShape: (s: ThemeShape) => void;
-  onSelectIconTheme: (t: IconTheme) => void;
-  onPickBg: () => void;
-  onClearBg: () => void;
-  onSelectScheme: (id: string) => void;
-  onSetWallpaperOpacity: (n: number) => void;
-  onClose: () => void;
-  t: (key: any) => string;
-}) {
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const close = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose();
-    };
-    const closeKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    document.addEventListener('mousedown', close);
-    document.addEventListener('keydown', closeKey);
-    return () => {
-      document.removeEventListener('mousedown', close);
-      document.removeEventListener('keydown', closeKey);
-    };
-  }, [onClose]);
-
-  const rect = anchorRef.current?.getBoundingClientRect();
-  const style: React.CSSProperties = {
-    position: 'fixed',
-    top: rect ? rect.bottom + 6 : 0,
-    left: rect ? Math.max(8, rect.left - 120) : 0,
-    minWidth: 260,
-  };
-
-  return createPortal(
-    <div className="ctx-menu theme-menu" ref={menuRef} style={style}>
-      <div className="theme-menu-section-label">{t('theme.section.color')}</div>
-      <div className="theme-swatch-grid">
-        {THEME_COLORS.map(c => (
-          <button
-            key={c.code}
-            className={`theme-swatch ${c.code === currentTheme ? 'active' : ''}`}
-            onClick={() => onSelectTheme(c.code)}
-            style={{ background: c.swatch, ['--swatch-ring' as any]: c.ring }}
-          >
-            <span className="theme-swatch-label">{t(c.labelKey as any)}</span>
-          </button>
-        ))}
-      </div>
-
-      <div className="ctx-menu-divider" />
-      <div className="theme-menu-section-label">{t('theme.section.shape')}</div>
-      <div className="theme-shape-row">
-        {THEME_SHAPES.map(s => (
-          <button
-            key={s.code}
-            className={`theme-shape-chip ${s.code === currentShape ? 'active' : ''}`}
-            onClick={() => onSelectShape(s.code)}
-          >
-            {s.label}
-          </button>
-        ))}
-      </div>
-
-      <div className="ctx-menu-divider" />
-
-      {/* Wallpaper picker + dim slider on its own row */}
-      <div className="theme-wallpaper-row">
-        <button
-          className={`theme-bg-btn ${hasBg ? 'has-bg' : ''}`}
-          onClick={hasBg ? onClearBg : onPickBg}
-        >
-          {hasBg ? (
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
-          ) : (
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><rect width="18" height="18" x="3" y="3" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
-          )}
-        </button>
-        <input
-          type="range"
-          min={0}
-          max={100}
-          step={5}
-          value={wallpaperOpacity}
-          onChange={(e) => onSetWallpaperOpacity(parseInt(e.target.value, 10))}
-          className="theme-dim-slider"
-          aria-label="Wallpaper opacity"
-        />
-        <span className="theme-dim-value">{wallpaperOpacity}%</span>
-      </div>
-
-      {/* Terminal foreground color scheme row */}
-      <div className="theme-bg-row">
-        <button
-          className={`term-fg-chip reset ${termColorScheme === '' ? 'active' : ''}`}
-          onClick={() => onSelectScheme('')}
-        >Aa</button>
-        {TERM_COLOR_SCHEMES.map(s => (
-          <button
-            key={s.id}
-            className={`term-fg-chip ${termColorScheme === s.id ? 'active' : ''}`}
-            style={{ color: s.fg }}
-            onClick={() => onSelectScheme(termColorScheme === s.id ? '' : s.id)}
-          >Aa</button>
-        ))}
-      </div>
-
-      <div className="ctx-menu-divider" />
-      <div className="theme-menu-section-label">{t('theme.section.icons')}</div>
-      <div className="theme-shape-row icon-theme-row">
-        {ICON_ART_THEMES.map(({ id, folderSrc }) => (
-          <button
-            key={id}
-            className={`icon-theme-chip ${currentIconTheme === id ? 'active' : ''}`}
-            onClick={() => onSelectIconTheme(id)}
-          >
-            {isMaskTintTheme(id) ? (
-              <span
-                className="icon-theme-chip-preview-mask"
-                style={{ WebkitMaskImage: `url("${folderSrc}")`, maskImage: `url("${folderSrc}")` }}
-                aria-label={id}
-              />
-            ) : (
-              <img src={folderSrc} alt={id} width="22" height="22" />
-            )}
-          </button>
-        ))}
-      </div>
-    </div>,
-    document.body
-  );
-}
-
 function formatBytes(b: number) {
   return b < 1024 ? b + ' B' : (b / 1024).toFixed(1) + ' KB';
 }
@@ -525,15 +269,6 @@ function getIconPath(theme: IconTheme, name: string): string {
 
 function getFileIconSrc(ext: string, theme: IconTheme): string {
   return `/icons/themes/${theme}/${getFileIcon(ext)}`;
-}
-
-// Themes whose SVGs use fill="currentColor" and should be tinted by the
-// current color theme's --accent. Rendered as <span> with mask-image so the
-// stroke color tracks the theme instead of being hardcoded in the SVG.
-const MASK_TINT_THEMES: IconTheme[] = ['devicon'];
-
-function isMaskTintTheme(theme: IconTheme): boolean {
-  return MASK_TINT_THEMES.includes(theme);
 }
 
 /** Renders a theme icon. For mask-tint themes, uses a <span> with mask-image
@@ -853,14 +588,6 @@ export function Explorer() {
     return () => window.removeEventListener('fs-refresh', handler);
   }, [folderPath]);
 
-  // Theme menu state
-  const [themeMenuOpen, setThemeMenuOpen] = useState(false);
-  const themeBtnRef = useRef<HTMLButtonElement>(null);
-
-  // Language dropdown state
-  const [langDropdownOpen, setLangDropdownOpen] = useState(false);
-  const langBtnRef = useRef<HTMLButtonElement>(null);
-
   // Update check
   const [hasUpdate, setHasUpdate] = useState(false);
   useEffect(() => {
@@ -1092,27 +819,10 @@ export function Explorer() {
         </div>
         
         <div className="window-controls">
-          {/* Language first — one-time setup, lives at the far-left of the
-              controls cluster so frequent actions sit closer to the edge. */}
-          <button
-            ref={langBtnRef}
-            className="icon-btn xs lang-btn lang-glyph"
-            onClick={() => setLangDropdownOpen(!langDropdownOpen)}
-          >
-            {getLangGlyph(state.currentLang)}
-          </button>
-          <button
-            ref={themeBtnRef}
-            className="icon-btn xs"
-            onClick={() => setThemeMenuOpen(v => !v)}
-          >
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-              <circle cx="9" cy="9" r="2" />
-              <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
-            </svg>
-          </button>
-          {/* Gambit last — frequently used, rightmost position for muscle
+          {/* Theme + language pickers moved to the titlebar gear →
+              SettingsModal. Gambit stays here — it's a compose action,
+              not a setting. */}
+          {/* Gambit — frequently used, rightmost position for muscle
               memory and thumb reach at the panel edge. */}
           <button
             className={`icon-btn xs ${state.gambitOpen ? 'active' : ''}`}
@@ -1222,66 +932,8 @@ export function Explorer() {
       {/* Right-click context menu */}
       {ctxMenu && <ContextMenu menu={ctxMenu} onClose={closeCtxMenu} />}
 
-      {/* Language dropdown */}
-      {langDropdownOpen && (
-        <LangDropdown
-          anchorRef={langBtnRef}
-          currentLang={state.currentLang}
-          onSelect={(code) => {
-            dispatch({ type: 'SET_LANG', lang: code });
-            try {
-              localStorage.setItem('cc-lang', code);
-              if (code !== 'en') localStorage.setItem('cc-native-lang', code);
-            } catch {}
-            setLangDropdownOpen(false);
-          }}
-          onClose={() => setLangDropdownOpen(false)}
-        />
-      )}
-
-      {/* Theme menu (color × shape × icon style × wallpaper × term fg) */}
-      {themeMenuOpen && (
-        <ThemeMenu
-          anchorRef={themeBtnRef}
-          currentTheme={state.currentTheme}
-          currentShape={state.currentShape}
-          currentIconTheme={state.iconTheme}
-          hasBg={state.bgType !== 'none' && state.bgPath !== ''}
-          termColorScheme={state.termColorScheme}
-          wallpaperOpacity={state.wallpaperOpacity}
-          onSelectTheme={(t) => dispatch({ type: 'SET_THEME', theme: t })}
-          onSelectShape={(s) => dispatch({ type: 'SET_SHAPE', shape: s })}
-          onSelectIconTheme={(t) => {
-            dispatch({ type: 'SET_ICON_THEME', theme: t });
-            try { localStorage.setItem('cc-icon-theme', t); } catch {}
-          }}
-          onPickBg={async () => {
-            try {
-              const { open } = await import('@tauri-apps/plugin-dialog');
-              const selected = await open({
-                filters: [{ name: 'Background', extensions: ['jpg', 'jpeg', 'png', 'gif', 'webp', 'mp4', 'webm'] }],
-              });
-              if (selected && typeof selected === 'string') {
-                const ext = selected.split('.').pop()?.toLowerCase() || '';
-                const bgType = ['mp4', 'webm'].includes(ext) ? 'video' : 'image';
-                try { localStorage.setItem('cc-bg-path', selected); localStorage.setItem('cc-bg-type', bgType); } catch {}
-                dispatch({ type: 'SET_BG', path: selected, bgType });
-              }
-            } catch (err) { console.error('[ThemeMenu] Background picker failed:', err); }
-          }}
-          onClearBg={() => {
-            try { localStorage.removeItem('cc-bg-path'); localStorage.removeItem('cc-bg-type'); } catch {}
-            dispatch({ type: 'CLEAR_BG' });
-          }}
-          onSelectScheme={(id) => {
-            try { id ? localStorage.setItem('cc-term-scheme', id) : localStorage.removeItem('cc-term-scheme'); } catch {}
-            dispatch({ type: 'SET_TERM_SCHEME', scheme: id });
-          }}
-          onSetWallpaperOpacity={(n) => dispatch({ type: 'SET_WALLPAPER_OPACITY', opacity: n })}
-          onClose={() => setThemeMenuOpen(false)}
-          t={t}
-        />
-      )}
+      {/* Theme + language pickers now live in the titlebar-gear SettingsModal
+          (App-level), not here. */}
     </div>
   );
 }

--- a/src-ui/src/components/right/TaskBoard.css
+++ b/src-ui/src/components/right/TaskBoard.css
@@ -377,7 +377,11 @@
   color: var(--text-3, rgba(255, 255, 255, 0.3));
 }
 
-/* Inline title edit — seamless, no border, same sizing as title */
+/* Inline title edit — seamless, no border, same sizing as title.
+   A <textarea> (not <input>) so long titles soft-wrap to multiple lines
+   while typing, matching the committed <span> below. Height is auto-grown
+   to scrollHeight in JS (see autoGrowTitle); resize/overflow off so no
+   manual handle or inner scrollbar appears. */
 .task-title-edit {
   flex: 1;
   font-size: 13px;
@@ -390,6 +394,12 @@
   padding: 0;
   margin: 0;
   outline: none;
+  resize: none;
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+  display: block;
+  box-sizing: border-box;
 }
 
 /* ─── Inline edit pencil (flows after the title text) ──────────────────────── */
@@ -430,12 +440,26 @@
   background: rgba(255, 255, 255, 0.06);
 }
 
+/* ─── Right-side action cluster ────────────────────────────────────────────── */
+/* Fixed-width box reserving the WIDEST mode (two 18px slots + 4px gap = 40px),
+   right-aligned. Edit mode shows a single ✓ that lands flush-right where the
+   play button sits; normal mode shows [delete][send]. Because the box width
+   never changes, the title's flex space is identical across modes — no
+   horizontal text jitter when entering/leaving edit. */
+.task-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  width: 40px;
+  flex-shrink: 0;
+}
+
 /* ─── Right-side fixed action slot ─────────────────────────────────────────── */
 /* One button, one position — identity swaps based on card mode:
      .task-slot-send    (normal)        → paper-plane, send to active agent
      .task-slot-confirm (editing title) → checkmark, commit edit
-     .task-slot-delete  (section delete mode) → trash, remove the task
-   Single slot avoids layout jitter as modes change. */
+     .task-slot-delete  (section delete mode) → trash, remove the task */
 .task-slot {
   display: flex;
   align-items: center;

--- a/src-ui/src/components/right/TaskBoard.css
+++ b/src-ui/src/components/right/TaskBoard.css
@@ -441,15 +441,16 @@
 }
 
 /* ─── Right-side action cluster ────────────────────────────────────────────── */
-/* Fixed-width box reserving the WIDEST mode (two 18px slots + 4px gap = 40px),
-   right-aligned. Edit mode shows a single ✓ that lands flush-right where the
-   play button sits; normal mode shows [delete][send]. Because the box width
-   never changes, the title's flex space is identical across modes — no
-   horizontal text jitter when entering/leaving edit. */
+/* Fixed-width box reserving the WIDEST mode (two 18px slots + 4px gap = 40px).
+   Because the box width never changes, the title's flex space is identical
+   across modes — no horizontal text jitter when entering/leaving edit.
+   Centered: normal mode's two icons fill the 40px exactly (so centering is a
+   no-op there), while edit mode's single ✓ sits centered in the reserved
+   space rather than pinned flush-right. */
 .task-actions {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
   gap: 4px;
   width: 40px;
   flex-shrink: 0;

--- a/src-ui/src/components/right/TaskBoard.tsx
+++ b/src-ui/src/components/right/TaskBoard.tsx
@@ -133,7 +133,15 @@ export function TaskBoard() {
   // Inline title editing
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
-  const editInputRef = useRef<HTMLInputElement>(null);
+  const editInputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-grow the title textarea to fit wrapped content (mirrors how the
+  // committed <span> title wraps), so long titles show on multiple lines
+  // WHILE typing instead of only after Enter.
+  const autoGrowTitle = useCallback((el: HTMLTextAreaElement) => {
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
 
 
   // Drag state — ALL refs to avoid stale closures
@@ -204,8 +212,9 @@ export function TaskBoard() {
     if (editingId && editInputRef.current) {
       editInputRef.current.focus();
       editInputRef.current.select();
+      autoGrowTitle(editInputRef.current); // fit a pre-existing long title
     }
-  }, [editingId]);
+  }, [editingId, autoGrowTitle]);
 
   // ─── Task Actions ─────────────────────────────────────────────────────────
   const handleAdd = useCallback(() => {
@@ -625,12 +634,22 @@ export function TaskBoard() {
                             ellipsis-truncates before the pencil so the pencil
                             is never pushed off-screen. */}
                         {isEditingThis ? (
-                          <input
+                          <textarea
                             ref={editInputRef}
                             className="task-title-edit"
                             value={editingTitle}
-                            onChange={e => setEditingTitle(e.target.value)}
+                            rows={1}
+                            onChange={e => {
+                              setEditingTitle(e.target.value);
+                              autoGrowTitle(e.currentTarget);
+                            }}
                             onKeyDown={e => {
+                              // IME composition in progress — let the IME keep
+                              // Enter for confirming candidates (CJK input);
+                              // committing here would drop the composition.
+                              if (e.nativeEvent.isComposing) return;
+                              // Enter commits (titles stay single-paragraph);
+                              // long text soft-wraps automatically, not via Enter.
                               if (e.key === 'Enter') { e.preventDefault(); commitEdit(); }
                               if (e.key === 'Escape') cancelEdit();
                             }}
@@ -655,47 +674,50 @@ export function TaskBoard() {
                           </span>
                         )}
 
-                        {/* Right-side action cluster.
-                            Editing mode: single ✓ confirm button.
-                            Normal mode: [delete] [send] — both opacity-faded
-                            at rest, revealed on card hover. Widths stay
-                            reserved so the title never shifts as icons fade. */}
-                        {isEditingThis ? (
-                          <button
-                            className="task-slot task-slot-confirm"
-                            onClick={e => { e.stopPropagation(); commitEdit(); }}
-                          >
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                              <polyline points="20 6 9 17 4 12" />
-                            </svg>
-                          </button>
-                        ) : (
-                          <>
+                        {/* Right-side action cluster — fixed-width box so the
+                            title's available width is IDENTICAL across modes
+                            (edit = single ✓, normal = [delete][send]). Without
+                            the reserved box the title shifts horizontally when
+                            entering/leaving edit. Icons are right-aligned, so
+                            the ✓ lands where the play button sits. */}
+                        <div className="task-actions">
+                          {isEditingThis ? (
                             <button
-                              className="task-slot task-slot-delete"
-                              onClick={e => { e.stopPropagation(); handleRemove(task.id); }}
+                              className="task-slot task-slot-confirm"
+                              onClick={e => { e.stopPropagation(); commitEdit(); }}
                             >
-                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                <polyline points="3 6 5 6 21 6"/>
-                                <path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/>
-                                <path d="M10 11v6"/><path d="M14 11v6"/>
-                                <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/>
+                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                <polyline points="20 6 9 17 4 12" />
                               </svg>
                             </button>
-                            <button
-                              className="task-slot task-slot-send"
-                              onClick={e => { e.stopPropagation(); sendToAgent(task); }}
-                              disabled={!state.activeTerminalId}
-                            >
-                              {/* Play triangle — reads as "start running this
-                                  task"; polygon spans the full viewBox to
-                                  match the sibling icon weight. */}
-                              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
-                                <polygon points="5 3 21 12 5 21"/>
-                              </svg>
-                            </button>
-                          </>
-                        )}
+                          ) : (
+                            <>
+                              <button
+                                className="task-slot task-slot-delete"
+                                onClick={e => { e.stopPropagation(); handleRemove(task.id); }}
+                              >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                  <polyline points="3 6 5 6 21 6"/>
+                                  <path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/>
+                                  <path d="M10 11v6"/><path d="M14 11v6"/>
+                                  <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/>
+                                </svg>
+                              </button>
+                              <button
+                                className="task-slot task-slot-send"
+                                onClick={e => { e.stopPropagation(); sendToAgent(task); }}
+                                disabled={!state.activeTerminalId}
+                              >
+                                {/* Play triangle — reads as "start running this
+                                    task"; polygon spans the full viewBox to
+                                    match the sibling icon weight. */}
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                                  <polygon points="5 3 21 12 5 21"/>
+                                </svg>
+                              </button>
+                            </>
+                          )}
+                        </div>
                       </div>
 
                       <div className={`task-desc-area ${isExpanded ? 'open' : ''}`}>

--- a/src-ui/src/components/right/TaskBoard.tsx
+++ b/src-ui/src/components/right/TaskBoard.tsx
@@ -678,8 +678,8 @@ export function TaskBoard() {
                             title's available width is IDENTICAL across modes
                             (edit = single ✓, normal = [delete][send]). Without
                             the reserved box the title shifts horizontally when
-                            entering/leaving edit. Icons are right-aligned, so
-                            the ✓ lands where the play button sits. */}
+                            entering/leaving edit. The lone ✓ is centered in the
+                            reserved space (see .task-actions). */}
                         <div className="task-actions">
                           {isEditingThis ? (
                             <button

--- a/src-ui/src/i18n/de.ts
+++ b/src-ui/src/i18n/de.ts
@@ -91,6 +91,20 @@ export const de = {
   // Session
   'session.max': 'Es können maximal 5 Sitzungen gleichzeitig geöffnet sein.',
 
+  // Settings modal (titlebar gear)
+  'settings.title': 'Einstellungen',
+  'settings.appearance': 'Darstellung',
+  'settings.wallpaper': 'Hintergrund',
+  'settings.terminal': 'Terminal',
+  'settings.gambit': 'Gambit',
+  'settings.language': 'Sprache',
+  'settings.wallpaper.pick': 'Bild oder Video wählen',
+  'settings.wallpaper.clear': 'Hintergrund entfernen',
+  'settings.wallpaper.opacity': 'Deckkraft',
+  'settings.terminal.scheme': 'Textfarbe',
+  'settings.send.title': 'Nachricht senden',
+  'settings.send.newline': 'für neue Zeile',
+
   // Theme Menu
   'theme.section.color': 'Farben',
   'theme.section.shape': 'Form',

--- a/src-ui/src/i18n/en.ts
+++ b/src-ui/src/i18n/en.ts
@@ -92,6 +92,20 @@ export const en = {
   // Session
   'session.max': 'Maximum 5 sessions can be open at once.',
 
+  // Settings modal (titlebar gear)
+  'settings.title': 'Settings',
+  'settings.appearance': 'Appearance',
+  'settings.wallpaper': 'Wallpaper',
+  'settings.terminal': 'Terminal',
+  'settings.language': 'Language',
+  'settings.wallpaper.pick': 'Choose image or video',
+  'settings.wallpaper.clear': 'Remove wallpaper',
+  'settings.wallpaper.opacity': 'Opacity',
+  'settings.terminal.scheme': 'Text color',
+  'settings.gambit': 'Gambit',
+  'settings.send.title': 'Send message',
+  'settings.send.newline': 'for a new line',
+
   // Theme Menu
   'theme.section.color': 'Colors',
   'theme.section.shape': 'Shape',
@@ -115,7 +129,7 @@ export const en = {
 
   // Gambit — floating compose window. Chess term for a calculated opening move.
   'gambit.title': 'GAMBIT',
-  'gambit.placeholder': 'Compose your move... (Ctrl+Enter to send, Enter for newline, paste images)',
+  'gambit.placeholder': 'Compose your move... ({send} to send, {newline} for newline, paste images)',
   'gambit.send_failed_hint': 'Open an active session first',
   'gambit.send_empty_hint': 'Type a message or paste an image first (Ctrl+V)',
 

--- a/src-ui/src/i18n/es.ts
+++ b/src-ui/src/i18n/es.ts
@@ -90,6 +90,20 @@ export const es = {
   // Session
   'session.max': 'Se pueden abrir un máximo de 5 sesiones a la vez.',
 
+  // Settings modal (titlebar gear)
+  'settings.title': 'Ajustes',
+  'settings.appearance': 'Apariencia',
+  'settings.wallpaper': 'Fondo',
+  'settings.terminal': 'Terminal',
+  'settings.gambit': 'Gambit',
+  'settings.language': 'Idioma',
+  'settings.wallpaper.pick': 'Elegir imagen o vídeo',
+  'settings.wallpaper.clear': 'Quitar fondo',
+  'settings.wallpaper.opacity': 'Opacidad',
+  'settings.terminal.scheme': 'Color del texto',
+  'settings.send.title': 'Enviar mensaje',
+  'settings.send.newline': 'para nueva línea',
+
   // Theme Menu
   'theme.section.color': 'Colores',
   'theme.section.shape': 'Forma',

--- a/src-ui/src/i18n/fr.ts
+++ b/src-ui/src/i18n/fr.ts
@@ -90,6 +90,20 @@ export const fr = {
   // Session
   'session.max': 'Vous ne pouvez pas ouvrir plus de 5 sessions simultanément.',
 
+  // Settings modal (titlebar gear)
+  'settings.title': 'Paramètres',
+  'settings.appearance': 'Apparence',
+  'settings.wallpaper': "Fond d'écran",
+  'settings.terminal': 'Terminal',
+  'settings.gambit': 'Gambit',
+  'settings.language': 'Langue',
+  'settings.wallpaper.pick': 'Choisir une image ou une vidéo',
+  'settings.wallpaper.clear': "Supprimer le fond d'écran",
+  'settings.wallpaper.opacity': 'Opacité',
+  'settings.terminal.scheme': 'Couleur du texte',
+  'settings.send.title': 'Envoyer le message',
+  'settings.send.newline': 'pour un saut de ligne',
+
   // Theme Menu
   'theme.section.color': 'Couleurs',
   'theme.section.shape': 'Forme',

--- a/src-ui/src/i18n/ja.ts
+++ b/src-ui/src/i18n/ja.ts
@@ -90,6 +90,20 @@ export const ja = {
   // Session
   'session.max': '同時に開けるセッションは最大 5 つです。',
 
+  // Settings modal (titlebar gear)
+  'settings.title': '設定',
+  'settings.appearance': '外観',
+  'settings.wallpaper': '壁紙',
+  'settings.terminal': 'ターミナル',
+  'settings.gambit': '一手',
+  'settings.language': '言語',
+  'settings.wallpaper.pick': '画像または動画を選択',
+  'settings.wallpaper.clear': '壁紙を削除',
+  'settings.wallpaper.opacity': '不透明度',
+  'settings.terminal.scheme': '文字色',
+  'settings.send.title': 'メッセージを送信',
+  'settings.send.newline': '改行',
+
   // Theme Menu
   'theme.section.color': 'カラー',
   'theme.section.shape': 'シェイプ',
@@ -113,7 +127,7 @@ export const ja = {
 
   // Gambit · 一手
   'gambit.title': '一手',
-  'gambit.placeholder': '静かに一手を思案... (Ctrl+Enterで送信、Enterで改行、画像貼付可)',
+  'gambit.placeholder': '静かに一手を思案... ({send}で送信、{newline}で改行、画像貼付可)',
   'gambit.send_failed_hint': 'アクティブなセッションを先に開いてください',
   'gambit.send_empty_hint': 'メッセージを入力するか画像を貼り付けてください (Ctrl+V)',
 

--- a/src-ui/src/i18n/ko.ts
+++ b/src-ui/src/i18n/ko.ts
@@ -90,6 +90,20 @@ export const ko = {
   // Session
   'session.max': '동시에 최대 5개의 세션만 열 수 있습니다.',
 
+  // Settings modal (titlebar gear)
+  'settings.title': '설정',
+  'settings.appearance': '외관',
+  'settings.wallpaper': '배경화면',
+  'settings.terminal': '터미널',
+  'settings.gambit': '한 수',
+  'settings.language': '언어',
+  'settings.wallpaper.pick': '이미지 또는 동영상 선택',
+  'settings.wallpaper.clear': '배경화면 제거',
+  'settings.wallpaper.opacity': '불투명도',
+  'settings.terminal.scheme': '글자 색',
+  'settings.send.title': '메시지 전송',
+  'settings.send.newline': '줄바꿈',
+
   // Theme Menu
   'theme.section.color': '색상',
   'theme.section.shape': '형태',
@@ -113,7 +127,7 @@ export const ko = {
 
   // Gambit · 한 수
   'gambit.title': '한 수',
-  'gambit.placeholder': '한 수를 고르는 중... (Ctrl+Enter 전송, Enter 줄바꿈, 이미지 붙여넣기)',
+  'gambit.placeholder': '한 수를 고르는 중... ({send} 전송, {newline} 줄바꿈, 이미지 붙여넣기)',
   'gambit.send_failed_hint': '활성 세션을 먼저 여세요',
   'gambit.send_empty_hint': '내용을 입력하거나 이미지를 붙여넣으세요 (Ctrl+V)',
 

--- a/src-ui/src/i18n/pt.ts
+++ b/src-ui/src/i18n/pt.ts
@@ -91,6 +91,20 @@ export const pt = {
   // Session
   'session.max': 'É possível ter no máximo 5 sessões abertas ao mesmo tempo.',
 
+  // Settings modal (titlebar gear)
+  'settings.title': 'Configurações',
+  'settings.appearance': 'Aparência',
+  'settings.wallpaper': 'Papel de parede',
+  'settings.terminal': 'Terminal',
+  'settings.gambit': 'Gambit',
+  'settings.language': 'Idioma',
+  'settings.wallpaper.pick': 'Escolher imagem ou vídeo',
+  'settings.wallpaper.clear': 'Remover papel de parede',
+  'settings.wallpaper.opacity': 'Opacidade',
+  'settings.terminal.scheme': 'Cor do texto',
+  'settings.send.title': 'Enviar mensagem',
+  'settings.send.newline': 'para nova linha',
+
   // Theme Menu
   'theme.section.color': 'Cores',
   'theme.section.shape': 'Forma',

--- a/src-ui/src/i18n/ru.ts
+++ b/src-ui/src/i18n/ru.ts
@@ -91,6 +91,20 @@ export const ru = {
   // Session
   'session.max': 'Можно открывать не более 5 сессий одновременно.',
 
+  // Settings modal (titlebar gear)
+  'settings.title': 'Настройки',
+  'settings.appearance': 'Оформление',
+  'settings.wallpaper': 'Обои',
+  'settings.terminal': 'Терминал',
+  'settings.gambit': 'Gambit',
+  'settings.language': 'Язык',
+  'settings.wallpaper.pick': 'Выбрать изображение или видео',
+  'settings.wallpaper.clear': 'Убрать обои',
+  'settings.wallpaper.opacity': 'Непрозрачность',
+  'settings.terminal.scheme': 'Цвет текста',
+  'settings.send.title': 'Отправить сообщение',
+  'settings.send.newline': 'для новой строки',
+
   // Theme Menu
   'theme.section.color': 'Цвета',
   'theme.section.shape': 'Форма',

--- a/src-ui/src/i18n/vi.ts
+++ b/src-ui/src/i18n/vi.ts
@@ -93,6 +93,20 @@ export const vi = {
   // Session
   'session.max': 'Tối đa 5 phiên có thể mở cùng lúc.',
 
+  // Settings modal (titlebar gear)
+  'settings.title': 'Cài đặt',
+  'settings.appearance': 'Giao diện',
+  'settings.wallpaper': 'Hình nền',
+  'settings.terminal': 'Terminal',
+  'settings.gambit': 'Nước cờ',
+  'settings.language': 'Ngôn ngữ',
+  'settings.wallpaper.pick': 'Chọn ảnh hoặc video',
+  'settings.wallpaper.clear': 'Xóa hình nền',
+  'settings.wallpaper.opacity': 'Độ mờ',
+  'settings.terminal.scheme': 'Màu chữ',
+  'settings.send.title': 'Gửi tin nhắn',
+  'settings.send.newline': 'để xuống dòng',
+
   // Theme Menu
   'theme.section.color': 'Màu sắc',
   'theme.section.shape': 'Hình dạng',
@@ -116,7 +130,7 @@ export const vi = {
 
   // Gambit · Nước cờ
   'gambit.title': 'Nước cờ',
-  'gambit.placeholder': 'Cân nhắc nước cờ... (Ctrl+Enter để gửi, Enter xuống dòng, dán ảnh được)',
+  'gambit.placeholder': 'Cân nhắc nước cờ... ({send} để gửi, {newline} xuống dòng, dán ảnh được)',
   'gambit.send_failed_hint': 'Hãy mở một phiên hoạt động trước',
   'gambit.send_empty_hint': 'Nhập nội dung hoặc dán ảnh trước (Ctrl+V)',
 

--- a/src-ui/src/i18n/zh-CN.ts
+++ b/src-ui/src/i18n/zh-CN.ts
@@ -90,6 +90,20 @@ export const zhCN = {
   // Session
   'session.max': '最多只能同时打开 5 个会话。',
 
+  // Settings modal (titlebar gear)
+  'settings.title': '设置',
+  'settings.appearance': '外观',
+  'settings.wallpaper': '壁纸',
+  'settings.terminal': '终端',
+  'settings.language': '语言',
+  'settings.wallpaper.pick': '选择图片或视频',
+  'settings.wallpaper.clear': '移除壁纸',
+  'settings.wallpaper.opacity': '透明度',
+  'settings.terminal.scheme': '文字颜色',
+  'settings.gambit': '妙手',
+  'settings.send.title': '发送消息',
+  'settings.send.newline': '换行',
+
   // Theme Menu
   'theme.section.color': '配色',
   'theme.section.shape': '形态',
@@ -113,7 +127,7 @@ export const zhCN = {
 
   // Gambit · 妙手
   'gambit.title': '妙手',
-  'gambit.placeholder': '静心琢磨，再落子... (Ctrl+Enter 发送, Enter 换行, 可粘贴图片)',
+  'gambit.placeholder': '静心琢磨，再落子... ({send} 发送, {newline} 换行, 可粘贴图片)',
   'gambit.send_failed_hint': '请先打开活动会话',
   'gambit.send_empty_hint': '先输入内容或粘贴图片 (Ctrl+V)',
 

--- a/src-ui/src/i18n/zh-TW.ts
+++ b/src-ui/src/i18n/zh-TW.ts
@@ -90,6 +90,20 @@ export const zhTW = {
   // Session
   'session.max': '最多只能同時開啟 5 個會話。',
 
+  // Settings modal (titlebar gear)
+  'settings.title': '設定',
+  'settings.appearance': '外觀',
+  'settings.wallpaper': '桌布',
+  'settings.terminal': '終端',
+  'settings.language': '語言',
+  'settings.wallpaper.pick': '選擇圖片或影片',
+  'settings.wallpaper.clear': '移除桌布',
+  'settings.wallpaper.opacity': '透明度',
+  'settings.terminal.scheme': '文字顏色',
+  'settings.gambit': '妙手',
+  'settings.send.title': '發送訊息',
+  'settings.send.newline': '換行',
+
   // Theme Menu
   'theme.section.color': '配色',
   'theme.section.shape': '形態',
@@ -113,7 +127,7 @@ export const zhTW = {
 
   // Gambit · 妙手
   'gambit.title': '妙手',
-  'gambit.placeholder': '靜心琢磨，再落子... (Ctrl+Enter 發送, Enter 換行, 可貼上圖片)',
+  'gambit.placeholder': '靜心琢磨，再落子... ({send} 發送, {newline} 換行, 可貼上圖片)',
   'gambit.send_failed_hint': '請先開啟活動工作階段',
   'gambit.send_empty_hint': '先輸入內容或貼上圖片 (Ctrl+V)',
 

--- a/src-ui/src/lib/personalization.ts
+++ b/src-ui/src/lib/personalization.ts
@@ -1,0 +1,75 @@
+// personalization.ts — shared, pure data for the appearance/language controls.
+//
+// Extracted from Explorer.tsx so the new SettingsModal and the file-tree's
+// icon renderer can both consume one source of truth (DRY). Only static option
+// tables + small pure helpers live here — all dispatch/persistence wiring stays
+// in the components.
+
+import type { ThemeColor, ThemeShape, IconTheme } from '../store/app-state';
+
+// ─── Theme colours (swatch grid) ─────────────────────────────────────────────
+export const THEME_COLORS: { code: ThemeColor; labelKey: string; swatch: string; ring: string }[] = [
+  { code: 'light',      labelKey: 'theme.color.light',      swatch: '#FAFAF7', ring: '#c4956a' },
+  { code: 'dark',       labelKey: 'theme.color.dark',       swatch: '#1a1917', ring: '#c4956a' },
+  { code: 'cappuccino', labelKey: 'theme.color.cappuccino', swatch: '#1a1a1a', ring: '#4a4a4a' },
+  { code: 'sakura',     labelKey: 'theme.color.sakura',     swatch: '#221b28', ring: '#f8b4c8' },
+  { code: 'lavender',   labelKey: 'theme.color.lavender',   swatch: '#221f2e', ring: '#c8b6ff' },
+  { code: 'mint',       labelKey: 'theme.color.mint',       swatch: '#142623', ring: '#7ae8c8' },
+  // Natural-material palette — independent of shape and terminal font color.
+  // Near-black with a faint hue, not "colored theme".
+  { code: 'obsidian',   labelKey: 'theme.color.obsidian',   swatch: '#0a0a0a', ring: '#5a5a5a' },
+  { code: 'cobalt',     labelKey: 'theme.color.cobalt',     swatch: '#0a1020', ring: '#5a85b8' },
+  { code: 'moss',       labelKey: 'theme.color.moss',       swatch: '#0b1612', ring: '#6a9878' },
+  // Spider-Man hero (pairs with the carbon shape).
+  { code: 'crimson',    labelKey: 'theme.color.crimson',    swatch: '#2a0d10', ring: '#e23b42' },
+  { code: 'sunset',     labelKey: 'theme.color.sunset',     swatch: '#241408', ring: '#f5803b' },
+  { code: 'amber',      labelKey: 'theme.color.amber',      swatch: '#20180a', ring: '#e8a72c' },
+  { code: 'emerald',    labelKey: 'theme.color.emerald',    swatch: '#0a1c12', ring: '#24c281' },
+  { code: 'teal',       labelKey: 'theme.color.teal',       swatch: '#0a2125', ring: '#2bc4c4' },
+  { code: 'indigo',     labelKey: 'theme.color.indigo',     swatch: '#12142e', ring: '#6172f0' },
+  { code: 'fuchsia',    labelKey: 'theme.color.fuchsia',    swatch: '#210f1d', ring: '#d94aa0' },
+];
+
+// ─── Theme shapes (corner/surface treatment) ─────────────────────────────────
+export const THEME_SHAPES: { code: ThemeShape; label: string }[] = [
+  { code: 'soft',   label: 'Soft'   },
+  { code: 'slab',   label: 'Slab'   },
+  { code: 'sharp',  label: 'Sharp'  },
+  { code: 'glass',  label: 'Glass'  },
+  { code: 'panel',  label: 'Panel'  },
+  { code: 'carbon', label: 'Carbon' },
+];
+
+// ─── File-tree icon art themes ───────────────────────────────────────────────
+export const ICON_ART_THEMES: { id: IconTheme; folderSrc: string }[] = [
+  { id: 'outline',          folderSrc: '/icons/themes/outline/folder-closed.svg'          },
+  { id: 'material',         folderSrc: '/icons/themes/material/folder-closed.svg'         },
+  { id: 'vscode-icons',     folderSrc: '/icons/themes/vscode-icons/folder-closed.svg'     },
+  { id: 'catppuccin-mocha', folderSrc: '/icons/themes/catppuccin-mocha/folder-closed.svg' },
+  { id: 'devicon',          folderSrc: '/icons/themes/devicon/folder-closed.svg'          },
+  { id: 'fluent',           folderSrc: '/icons/themes/fluent/folder-closed.svg'           },
+  { id: 'symbols',          folderSrc: '/icons/themes/symbols/folder-closed.svg'          },
+  { id: 'coffee',           folderSrc: '/icons/themes/coffee/folder-closed.svg'           },
+];
+
+// Themes whose SVGs use fill="currentColor" and should be tinted by the active
+// theme's --accent (rendered via mask-image instead of <img>).
+export const MASK_TINT_THEMES: IconTheme[] = ['devicon'];
+export function isMaskTintTheme(theme: IconTheme): boolean {
+  return MASK_TINT_THEMES.includes(theme);
+}
+
+// ─── Languages ───────────────────────────────────────────────────────────────
+export const LANGUAGES = [
+  { code: 'en',    label: 'English',    glyph: 'A'  },
+  { code: 'zh-CN', label: '简体中文',   glyph: '文' },
+  { code: 'zh-TW', label: '繁體中文',   glyph: '文' },
+  { code: 'ja',    label: '日本語',     glyph: 'あ' },
+  { code: 'ko',    label: '한국어',     glyph: '가' },
+  { code: 'es',    label: 'Español',    glyph: 'Ñ'  },
+  { code: 'fr',    label: 'Français',   glyph: 'Fr' },
+  { code: 'de',    label: 'Deutsch',    glyph: 'De' },
+  { code: 'pt',    label: 'Português',  glyph: 'Pt' },
+  { code: 'ru',    label: 'Русский',    glyph: 'Я'  },
+  { code: 'vi',    label: 'Tiếng Việt', glyph: 'Vi' },
+];

--- a/src-ui/src/store/app-state.tsx
+++ b/src-ui/src/store/app-state.tsx
@@ -119,6 +119,15 @@ export interface AppState {
   // per-tab (stored on TerminalSession.gambitDraft).
   gambitOpen: boolean;
 
+  // Personalization settings modal (opened by the titlebar gear). App-level
+  // so the titlebar gear and the App-mounted modal share one flag.
+  settingsOpen: boolean;
+
+  // Gambit compose-box send key. true → Enter sends (Shift/Ctrl/Cmd+Enter =
+  // newline); false → Ctrl/Cmd+Enter sends (Enter = newline). Chosen in the
+  // settings modal because the muscle-memory split is per-user / per-OS.
+  gambitEnterToSend: boolean;
+
   // IDE-style layout toggles driven from titlebar controls.
   // Default both panels visible — matches first-time user expectation.
   leftPanelHidden: boolean;
@@ -191,6 +200,9 @@ type Action =
   | { type: 'SET_WALLPAPER_OPACITY'; opacity: number }
   | { type: 'SET_TERM_SCHEME'; scheme: string }
   | { type: 'TOGGLE_GAMBIT' }
+  | { type: 'TOGGLE_SETTINGS' }
+  | { type: 'SET_SETTINGS_OPEN'; open: boolean }
+  | { type: 'SET_GAMBIT_ENTER_TO_SEND'; value: boolean }
   | { type: 'SET_GAMBIT_DRAFT'; id: string; draft: string }
   | { type: 'SET_PANE_TOOL'; tabId: string; paneIdx: number; tool: ToolType; toolData?: string; folderPath?: string | null }
   | { type: 'SET_PANE_SENTINEL'; tabId: string; paneIdx: number; enabled: boolean }
@@ -327,6 +339,12 @@ function reducer(state: AppState, action: Action): AppState {
       return { ...state, termColorScheme: action.scheme };
     case 'TOGGLE_GAMBIT':
       return { ...state, gambitOpen: !state.gambitOpen };
+    case 'TOGGLE_SETTINGS':
+      return { ...state, settingsOpen: !state.settingsOpen };
+    case 'SET_SETTINGS_OPEN':
+      return { ...state, settingsOpen: action.open };
+    case 'SET_GAMBIT_ENTER_TO_SEND':
+      return { ...state, gambitEnterToSend: action.value };
     case 'SET_GAMBIT_DRAFT':
       return {
         ...state,
@@ -474,6 +492,8 @@ function getInitialState(): AppState {
   let bgType: 'image' | 'video' | 'none' = 'none';
   let termColorScheme = '';
   let wallpaperOpacity = 70;
+  // Default Enter-to-send; only opt-out if the user explicitly stored 'false'.
+  let gambitEnterToSend = true;
   try {
     const storedPath = localStorage.getItem('cc-bg-path');
     const storedType = localStorage.getItem('cc-bg-type') as 'image' | 'video' | 'none' | null;
@@ -495,6 +515,7 @@ function getInitialState(): AppState {
     }
 
     termColorScheme = localStorage.getItem('cc-term-scheme') || '';
+    gambitEnterToSend = localStorage.getItem('cc-gambit-enter-send') !== 'false';
     // New key (post-refactor): wallpaper opacity, 0-100, larger = more
     // visible. Old key was `cc-wallpaper-dim` (0-80, larger = darker
     // overlay). On first load after upgrade, fall back to the legacy
@@ -540,6 +561,8 @@ function getInitialState(): AppState {
     terminals: [{ id: defaultTerminalId, tool: null, folderPath }],
     activeTerminalId: defaultTerminalId,
     gambitOpen: false,
+    settingsOpen: false,
+    gambitEnterToSend,
     leftPanelHidden,
     rightPanelHidden,
     multiAgentLayout,

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Coffee CLI",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "identifier": "com.coffeecli.desktop",
   "build": {
     "frontendDist": "./src-ui/dist",


### PR DESCRIPTION
Release 2.9.2.

- New titlebar-gear settings modal consolidating theme/wallpaper/terminal/language (+ two-tone theme cards, shape-aware radii).
- Gambit send-key choice (Enter vs Ctrl/⌘+Enter) with dynamic placeholder; version in rail footer.
- Fix: stale WebGL frame ghost on tab switch (#47).
- Task title wraps while editing + centered confirm ✓.
- Settings strings across all 11 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)