### PR TITLE
web: move enterprise section below the feature demo

### DIFF
--- a/Web-Home/index.html
+++ b/Web-Home/index.html
@@ -161,14 +161,6 @@
     <a href="https://gitcode.com/edison7009/Coffee-CLI/issues" target="_blank" rel="noopener" data-i18n="cn-mirrors-feedback">国内用户问题反馈</a>
   </section>
 
-  <!-- Enterprise procurement / commercial licensing. Anchor target for the
-       navbar "Enterprise" link; copy mirrors the README's commercial section. -->
-  <section class="enterprise-section" id="enterprise">
-    <h2 class="enterprise-title" data-i18n="enterprise-title">Enterprise &amp; commercial licensing</h2>
-    <p class="enterprise-body" data-i18n="enterprise-body">The open-source edition is <strong>free, forever</strong> (AGPL-3.0) — companies are welcome to use it as-is. You only need a paid commercial license to step outside AGPL's copyleft: to <strong>customize Coffee CLI and keep your changes closed-source</strong>, <strong>ship it under your own brand / white-label</strong>, or <strong>embed it in a proprietary product you distribute</strong>. <strong>Custom development, priority support, and SLAs</strong> are available too. Tell us what you're building and we'll tailor a quote.</p>
-    <a class="enterprise-contact" href="mailto:ebenxp707@gmail.com?subject=Coffee%20CLI%20Enterprise" data-i18n="enterprise-contact">Contact us →</a>
-  </section>
-
   <!-- Direct Download Section ------------------------------------------------
        For users who prefer click-and-install over running the install
        command above. Each button hits the CF Worker's /download/<platform>
@@ -274,6 +266,15 @@
       </div>
 
     </div>
+  </section>
+
+  <!-- Enterprise procurement / commercial licensing. Anchor target for the
+       navbar "Enterprise" link. Placed low — after the feature demo — so
+       regular users meet the product first; copy mirrors the README. -->
+  <section class="enterprise-section" id="enterprise">
+    <h2 class="enterprise-title" data-i18n="enterprise-title">Enterprise &amp; commercial licensing</h2>
+    <p class="enterprise-body" data-i18n="enterprise-body">The open-source edition is <strong>free, forever</strong> (AGPL-3.0) — companies are welcome to use it as-is. You only need a paid commercial license to step outside AGPL's copyleft: to <strong>customize Coffee CLI and keep your changes closed-source</strong>, <strong>ship it under your own brand / white-label</strong>, or <strong>embed it in a proprietary product you distribute</strong>. <strong>Custom development, priority support, and SLAs</strong> are available too. Tell us what you're building and we'll tailor a quote.</p>
+    <a class="enterprise-contact" href="mailto:ebenxp707@gmail.com?subject=Coffee%20CLI%20Enterprise" data-i18n="enterprise-contact">Contact us →</a>
   </section>
 
   <footer style="text-align: center; padding: 2.5rem 1rem 3rem; font-size: 0.8rem; color: var(--text-secondary); opacity: 0.6; line-height: 1.7;">


### PR DESCRIPTION
The procurement CTA was too high (right under downloads). Move #enterprise to after the feature demo, above the footer, so regular users see the product first. Navbar anchor unchanged; HTML-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)