### PR TITLE
feat: native hook forwarder + terminal shell auto-detect + library icon (2.9.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "coffee-cli"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coffee-cli"
-version = "2.9.2"
+version = "2.9.3"
 edition = "2021"
 description = "Lightweight Multi-layer AI CLI Terminal"
 license = "AGPL-3.0-or-later"

--- a/install/release-notes-template.md
+++ b/install/release-notes-template.md
@@ -1,59 +1,49 @@
 <details open>
 <summary><b>🇨🇳 简体中文</b></summary>
 
-- 全新设置中心:标题栏齿轮一处集中调整主题配色、壁纸、终端文字色与界面语言,告别挤在侧栏的弹出菜单。
-- 主题选择改为双色预览卡,一眼看清每个主题的背景色与强调色。
-- 「妙手」输入框可自选发送键:默认 Enter 发送、Shift+Enter 换行,也能切换为 Ctrl/⌘+Enter 发送。
-- 设置面板底部显示当前版本号。
-- 修复:切换标签页时偶尔闪现上一帧的残影。
-- 优化:编辑任务标题时长文字自动换行。
+- 终端默认自动使用已安装的 PowerShell 7(pwsh),未安装则沿用系统自带版本。
+- macOS / Linux 的终端改为跟随系统默认 shell(zsh、fish 等),不再固定使用 bash。
+- Claude / Codex 标签页的运行状态指示更准确、更稳定;修复部分 Windows(未安装 Python)机器上出现的 hook 报错提示。
+- 「选择工具」入口图标更直观,与设置入口区分更清晰。
 
 </details>
 
 <details>
 <summary><b>🇹🇼 繁體中文</b></summary>
 
-- 全新設定中心:標題列齒輪一處集中調整主題配色、桌布、終端文字色與介面語言,告別擠在側欄的彈出選單。
-- 主題選擇改為雙色預覽卡,一眼看清每個主題的背景色與強調色。
-- 「妙手」輸入框可自選發送鍵:預設 Enter 發送、Shift+Enter 換行,也能切換為 Ctrl/⌘+Enter 發送。
-- 設定面板底部顯示目前版本號。
-- 修復:切換分頁時偶爾閃現上一幀的殘影。
-- 最佳化:編輯任務標題時長文字自動換行。
+- 終端預設自動使用已安裝的 PowerShell 7(pwsh),未安裝則沿用系統內建版本。
+- macOS / Linux 的終端改為跟隨系統預設 shell(zsh、fish 等),不再固定使用 bash。
+- Claude / Codex 分頁的執行狀態指示更準確、更穩定;修復部分 Windows(未安裝 Python)機器上出現的 hook 錯誤提示。
+- 「選擇工具」入口圖示更直觀,與設定入口區分更清晰。
 
 </details>
 
 <details>
 <summary><b>🇬🇧 English</b></summary>
 
-- New settings center: one titlebar gear for theme colors, wallpaper, terminal text color, and interface language — no more menus crammed into the sidebar.
-- Theme picker now uses two-tone preview cards, so you can see each theme's background and accent at a glance.
-- Gambit compose box now lets you choose your send key — Enter to send / Shift+Enter for a newline (default), or Ctrl/⌘+Enter to send.
-- The current version is shown at the bottom of the settings panel.
-- Fixed: a brief ghost of the previous frame when switching tabs.
-- Improved: long task titles now wrap while you're editing them.
+- The terminal now uses your installed PowerShell 7 (pwsh) by default, falling back to the built-in version if it isn't installed.
+- On macOS / Linux the terminal follows your system default shell (zsh, fish, …) instead of always using bash.
+- The Claude / Codex tab status indicator is more accurate and reliable; fixed a hook error message that appeared on some Windows machines without Python.
+- The "choose tool" entry icon is clearer and easier to tell apart from settings.
 
 </details>
 
 <details>
 <summary><b>🇯🇵 日本語</b></summary>
 
-- 新しい設定センター:タイトルバーの歯車から、テーマカラー・壁紙・ターミナル文字色・表示言語をまとめて調整。サイドバーに散らばっていたメニューが不要になりました。
-- テーマ選択が二色プレビューカードに。各テーマの背景色とアクセント色がひと目で分かります。
-- 「一手」入力欄で送信キーを選べるように:既定は Enter で送信・Shift+Enter で改行、Ctrl/⌘+Enter での送信にも切り替え可能。
-- 設定パネル下部に現在のバージョンを表示。
-- 修正:タブ切り替え時に前の画面が一瞬残る残像。
-- 改善:タスクのタイトル編集中、長い文字が自動で折り返されます。
+- ターミナルが既定でインストール済みの PowerShell 7(pwsh)を使用するようになりました。未インストールの場合は標準版にフォールバックします。
+- macOS / Linux では、ターミナルが常に bash ではなくシステム既定のシェル(zsh、fish など)に追従するようになりました。
+- Claude / Codex タブの実行状態表示がより正確・安定に。Python が入っていない一部の Windows 環境で表示されていた hook エラーを修正しました。
+- 「ツールを選択」入口アイコンをより分かりやすくし、設定と区別しやすくしました。
 
 </details>
 
 <details>
 <summary><b>🇰🇷 한국어</b></summary>
 
-- 새로운 설정 센터: 타이틀바 톱니바퀴 하나로 테마 색상 · 배경화면 · 터미널 글자색 · 인터페이스 언어를 한곳에서 조정. 사이드바에 흩어져 있던 메뉴가 사라졌습니다.
-- 테마 선택이 두 가지 색 미리보기 카드로 바뀌어, 각 테마의 배경색과 강조색을 한눈에 볼 수 있습니다.
-- 「한 수」 입력창에서 전송 키를 선택할 수 있습니다: 기본은 Enter 전송 · Shift+Enter 줄바꿈, Ctrl/⌘+Enter 전송으로 전환 가능.
-- 설정 패널 하단에 현재 버전이 표시됩니다.
-- 수정: 탭 전환 시 이전 화면이 잠깐 남는 잔상.
-- 개선: 작업 제목 편집 중 긴 글자가 자동으로 줄바꿈됩니다.
+- 터미널이 기본적으로 설치된 PowerShell 7(pwsh)을 사용합니다. 설치되어 있지 않으면 기본 제공 버전으로 대체됩니다.
+- macOS / Linux에서 터미널이 항상 bash가 아니라 시스템 기본 셸(zsh, fish 등)을 따르도록 변경되었습니다.
+- Claude / Codex 탭의 실행 상태 표시가 더 정확하고 안정적입니다. Python이 없는 일부 Windows에서 나타나던 hook 오류 메시지를 수정했습니다.
+- '도구 선택' 진입 아이콘을 더 직관적으로 바꾸고 설정과 구분이 쉬워졌습니다.
 
 </details>

--- a/src-ui/src/components/center/CenterPanel.tsx
+++ b/src-ui/src/components/center/CenterPanel.tsx
@@ -1707,16 +1707,19 @@ export function CenterPanel() {
                 aria-label="Open library"
               >
                 <div className="mode-switch-icon">
-                  {/* Gear at entry = "manage your tools" (broad scope).
-                      Per-tool gears inside = "configure this tool"
-                      (narrow scope). Same symbol, nested semantics —
-                      same pattern as magnifying glass for global vs
-                      in-page search. Globally trained "齿轮 = 设置"
-                      mental model beats the abstract 9-dot grid for
-                      mass-market users. */}
+                  {/* 2×2 app grid = "open the tools/apps library" — the
+                      macOS Launchpad / iOS App Library metaphor for this
+                      button's actual job. The "+" in the last cell reads as
+                      "more / add a tool". Replaces the former gear, which
+                      collided with the settings-screen gear and mis-read as
+                      "设置" rather than "应用页". A grid is concrete here, not
+                      abstract — it depicts the apps the button opens. */}
                   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <circle cx="12" cy="12" r="3"/>
-                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+                    <rect x="3" y="3" width="7.5" height="7.5" rx="1.6"/>
+                    <rect x="13.5" y="3" width="7.5" height="7.5" rx="1.6"/>
+                    <rect x="3" y="13.5" width="7.5" height="7.5" rx="1.6"/>
+                    <line x1="17.25" y1="14.3" x2="17.25" y2="20.2"/>
+                    <line x1="14.3" y1="17.25" x2="20.2" y2="17.25"/>
                   </svg>
                 </div>
               </button>

--- a/src/hook_forwarder.rs
+++ b/src/hook_forwarder.rs
@@ -1,0 +1,181 @@
+// Coffee CLI — native hook forwarder
+//
+// Invoked as a Claude Code hook (`<exe> __hook`, event JSON on stdin) or a
+// Codex `notify` target (`<exe> __codex-notify <json>`, payload as final
+// argv). Maps the event to Coffee CLI's 3-state agent status and forwards a
+// compact JSON line to the Rust hook server over loopback TCP.
+//
+// Replaces the two Python forwarders:
+//   - scripts/coffee-cli-hook.py         (Claude, stdin protocol)
+//   - scripts/coffee-cli-codex-notify.py (Codex, argv-tail protocol)
+// which are now kept only as protocol-reference copies under
+// ~/.coffee-cli/hooks/.
+//
+// Why native: the Python forwarder failed on Windows machines without
+// Python — `python` resolved to the Microsoft Store alias stub, which
+// prints "Python was not found…" to stderr and exits non-zero, so Claude
+// Code surfaced a "UserPromptSubmit hook error" in the transcript on every
+// prompt. The shipped binary is always present and needs no interpreter, so
+// pointing the hook at ourselves removes the dependency entirely — the same
+// "ship a native binary as the hook command" pattern CCometixLine uses for
+// its statusline.
+//
+// Discipline mirrored from the Python scripts: every path exits 0. A flaky
+// forwarder must never block the agent.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+/// Env injected by Coffee CLI when spawning a tool in a tab (see
+/// terminal.rs). Without `COFFEE_CLI_TAB_ID` + `COFFEE_CLI_HOOK_PORT` the
+/// forwarder no-ops — that's the gate that keeps the globally-registered
+/// Codex `notify` silent for sessions started outside Coffee CLI.
+struct HookCtx {
+    tab_id: String,
+    port: u16,
+    tool: String,
+}
+
+impl HookCtx {
+    fn from_env() -> Option<HookCtx> {
+        let tab_id = std::env::var("COFFEE_CLI_TAB_ID")
+            .ok()
+            .filter(|s| !s.is_empty())?;
+        let port = std::env::var("COFFEE_CLI_HOOK_PORT")
+            .ok()?
+            .parse::<u16>()
+            .ok()?;
+        let tool = std::env::var("COFFEE_CLI_TOOL").unwrap_or_default();
+        Some(HookCtx { tab_id, port, tool })
+    }
+}
+
+/// `<exe> __hook` — Claude Code stdin hook protocol. Never returns.
+pub fn run_claude_hook() -> ! {
+    let _ = forward_claude();
+    std::process::exit(0);
+}
+
+/// `<exe> __codex-notify <json>` — Codex `notify` argv-tail protocol.
+/// Never returns.
+pub fn run_codex_notify(args: &[String]) -> ! {
+    let _ = forward_codex(args);
+    std::process::exit(0);
+}
+
+fn forward_claude() -> Option<()> {
+    let ctx = HookCtx::from_env()?;
+
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf).ok()?;
+    // Tolerate a leading UTF-8 BOM — some shells/redirects prepend one and it
+    // would otherwise break JSON parsing.
+    let buf = buf.trim_start_matches('\u{feff}');
+    let data: Value = serde_json::from_str(buf).ok()?;
+
+    let event = data
+        .get("hook_event_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let status = map_claude_status(&data, &event)?;
+
+    post(ctx.port, &ctx.tab_id, &ctx.tool, &status, &event);
+    Some(())
+}
+
+fn forward_codex(args: &[String]) -> Option<()> {
+    // Codex appends the event JSON as the FINAL argv argument
+    // (codex-rs/hooks/src/legacy_notify.rs). With our registered
+    // `notify = ["<exe>", "__codex-notify"]`, argv is
+    // [exe, "__codex-notify", "<json>"] so the payload is the last arg.
+    // A malformed/absent payload simply fails to parse → no-op.
+    let payload = args.last()?;
+    let data: Value = serde_json::from_str(payload.trim_start_matches('\u{feff}')).ok()?;
+
+    let ctx = HookCtx::from_env()?;
+    // `notify` is global Codex config and fires for sessions started
+    // outside Coffee CLI too — gate strictly on the tool tag.
+    if ctx.tool != "codex" {
+        return None;
+    }
+
+    let event = data
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let status = map_codex_status(&event)?;
+
+    post(ctx.port, &ctx.tab_id, &ctx.tool, &status, &event);
+    Some(())
+}
+
+/// Map a Claude Code hook event to a tab status. Mirrors
+/// coffee-cli-hook.py exactly: Stop → idle, permission_prompt → wait_input,
+/// idle_prompt → idle, everything else busy (working).
+fn map_claude_status(data: &Value, event: &str) -> Option<String> {
+    match event {
+        "Stop" | "StopFailure" => Some("idle".to_string()),
+        "Notification" => {
+            // Claude has exposed the subtype under different keys across
+            // versions — check all three the Python script checked.
+            let ntype = data
+                .get("notification_type")
+                .and_then(|v| v.as_str())
+                .or_else(|| data.get("type").and_then(|v| v.as_str()))
+                .or_else(|| {
+                    data.get("notification")
+                        .and_then(|n| n.get("type"))
+                        .and_then(|v| v.as_str())
+                });
+            match ntype {
+                Some("permission_prompt") => Some("wait_input".to_string()),
+                Some("idle_prompt") => Some("idle".to_string()),
+                _ => None,
+            }
+        }
+        // UserPromptSubmit / PreToolUse / PostToolUse / SubagentStart /
+        // PreCompact / etc. (and a missing event name) → busy. One bucket,
+        // one color.
+        _ => Some("working".to_string()),
+    }
+}
+
+/// Map a Codex `notify` event to a tab status. Codex only signals turn
+/// completion (never turn start); unknown types are ignored, not guessed.
+fn map_codex_status(event: &str) -> Option<String> {
+    match event {
+        "agent-turn-complete" => Some("idle".to_string()),
+        _ => None,
+    }
+}
+
+/// One TCP connection per event to the loopback hook server. Every error is
+/// swallowed — the forwarder must never block the agent.
+fn post(port: u16, tab_id: &str, tool: &str, status: &str, event: &str) {
+    let payload = json!({
+        "tab_id": tab_id,
+        "tool": tool,
+        "status": status,
+        "event": event,
+    });
+    let _ = send(port, &payload);
+}
+
+fn send(port: u16, payload: &Value) -> std::io::Result<()> {
+    let addr = format!("127.0.0.1:{}", port)
+        .parse()
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "addr"))?;
+    let mut stream = TcpStream::connect_timeout(&addr, Duration::from_secs(1))?;
+    stream.set_write_timeout(Some(Duration::from_secs(1)))?;
+    stream.set_read_timeout(Some(Duration::from_secs(1)))?;
+    stream.write_all(format!("{}\n", payload).as_bytes())?;
+    // Drain the server's tiny ack so it can close cleanly; ignore content.
+    let mut ack = [0u8; 256];
+    let _ = stream.read(&mut ack);
+    Ok(())
+}

--- a/src/hook_installer.rs
+++ b/src/hook_installer.rs
@@ -3,17 +3,25 @@
 // At app launch, ensure all three integrated CLIs are wired to the dynamic
 // island status bus:
 //
+// The forwarder is the Coffee CLI binary itself (`<exe> __hook` /
+// `<exe> __codex-notify`, implemented in hook_forwarder.rs) — NOT a Python
+// script. The Python forwarders failed on Windows machines without Python
+// (`python` hit the MS Store alias stub → "python not found" hook errors in
+// Claude's transcript); a native subcommand on the always-present binary
+// removes the interpreter dependency entirely. The .py files are still
+// dropped under ~/.coffee-cli/hooks/ as protocol-reference copies only.
+//
 //   Claude Code
-//     1. ~/.coffee-cli/hooks/coffee-cli-hook.py — Claude stdin hook protocol
-//     2. ~/.claude/settings.json — registers our hook on 5 events
-//     3. ~/.claude/settings.local.json — stale entries from v1.8.5 stripped
+//     1. ~/.claude/settings.json — registers `<exe> __hook` on 5 events
+//     2. ~/.claude/settings.local.json — stale entries from v1.8.5 stripped
+//     3. ~/.coffee-cli/hooks/coffee-cli-hook.py — reference copy (unused)
 //
 //   Codex
-//     1. ~/.coffee-cli/hooks/coffee-cli-codex-notify.py — argv[-1] JSON
-//     2. ~/.codex/config.toml — `notify = ["python", "<path>"]` line, only
-//        added if there's no top-level `notify` already (don't clobber user
-//        config). The script is global to all Codex sessions but no-ops
-//        when COFFEE_CLI_* env vars are absent.
+//     1. ~/.codex/config.toml — `notify = ["<exe>", "__codex-notify"]` line,
+//        only added if there's no top-level `notify` already (don't clobber
+//        user config). It's global to all Codex sessions but no-ops when the
+//        COFFEE_CLI_* env vars are absent.
+//     2. ~/.coffee-cli/hooks/coffee-cli-codex-notify.py — reference copy
 //
 //   OpenCode
 //     1. ~/.config/opencode/plugins/coffee-cli-island.js — auto-loaded by
@@ -50,6 +58,14 @@ const SCRIPT_FILENAME: &str = "coffee-cli-hook.py";
 
 const CODEX_NOTIFY_SCRIPT: &str = include_str!("../scripts/coffee-cli-codex-notify.py");
 const CODEX_NOTIFY_FILENAME: &str = "coffee-cli-codex-notify.py";
+
+/// Argv markers for the native forwarder built into the Coffee CLI binary
+/// (see hook_forwarder.rs). The hook command is now `<exe> __hook` /
+/// `<exe> __codex-notify` — no Python. These tokens double as the
+/// "is this our entry?" sentinel so re-installs are idempotent and old
+/// Python-based entries get migrated in place.
+const HOOK_SUBCOMMAND: &str = "__hook";
+const CODEX_NOTIFY_SUBCOMMAND: &str = "__codex-notify";
 
 const OPENCODE_PLUGIN_SCRIPT: &str = include_str!("../scripts/coffee-cli-opencode-plugin.js");
 const OPENCODE_PLUGIN_FILENAME: &str = "coffee-cli-island.js";
@@ -154,10 +170,20 @@ const OPENCODE_DEFAULT_THEME: &str = "lucent-orng";
 const OPENCODE_LEGACY_THEME: &str = "system";
 
 fn install_claude(home: &Path) {
-    let script_path = match write_script(home) {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("[hook-installer] failed to write claude hook: {}", e);
+    // Keep a protocol-reference copy of the Python forwarder co-located with
+    // the other tools' debug copies. It's no longer the registered command
+    // (the native binary is — see below), so a write failure is non-fatal.
+    if let Err(e) = write_script(home) {
+        eprintln!("[hook-installer] failed to write claude hook reference copy: {}", e);
+    }
+
+    // The hook command is the Coffee CLI binary itself: `<exe> __hook`. No
+    // interpreter dependency — this is what fixes the "python not found"
+    // hook error on Windows machines without Python.
+    let command = match claude_hook_command() {
+        Some(c) => c,
+        None => {
+            eprintln!("[hook-installer] current_exe() failed — cannot install claude hook");
             return;
         }
     };
@@ -166,7 +192,7 @@ fn install_claude(home: &Path) {
     // tried in v1.8.5 but hooks declared there fire unreliably under Claude
     // Code v2.x (workspace-trust gate, cf. anthropics/claude-code#11519).
     let primary = home.join(".claude").join("settings.json");
-    if let Err(e) = patch_settings(&primary, &script_path) {
+    if let Err(e) = patch_settings(&primary, &command) {
         eprintln!(
             "[hook-installer] failed to patch {}: {}",
             primary.display(),
@@ -189,25 +215,28 @@ fn install_claude(home: &Path) {
     }
 }
 
-/// Codex notify forwarder — keeps ~/.coffee-cli/hooks/<filename> fresh and
-/// adds a `notify = [...]` line to ~/.codex/config.toml if (and only if) the
-/// user doesn't already have one. We never overwrite an existing notify
-/// command — too high a risk of stomping on the user's setup.
+/// Codex notify forwarder — registers `notify = ["<exe>", "__codex-notify"]`
+/// in ~/.codex/config.toml if (and only if) the user doesn't already have a
+/// top-level notify. The forwarder is the Coffee CLI binary itself (no
+/// Python). We never overwrite a user's custom notify command — too high a
+/// risk of stomping on their setup.
 fn install_codex(home: &Path) {
-    let script_path = match write_aux_script(
-        home,
-        CODEX_NOTIFY_FILENAME,
-        CODEX_NOTIFY_SCRIPT,
-    ) {
+    // Protocol-reference copy alongside the other forwarders' debug copies.
+    // No longer the registered command, so a write failure is non-fatal.
+    if let Err(e) = write_aux_script(home, CODEX_NOTIFY_FILENAME, CODEX_NOTIFY_SCRIPT) {
+        eprintln!("[hook-installer] failed to write codex notify reference copy: {}", e);
+    }
+
+    let exe = match std::env::current_exe() {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("[hook-installer] failed to write codex notify: {}", e);
+            eprintln!("[hook-installer] current_exe() failed — cannot install codex notify: {}", e);
             return;
         }
     };
 
     let config_path = home.join(".codex").join("config.toml");
-    if let Err(e) = patch_codex_config(&config_path, &script_path) {
+    if let Err(e) = patch_codex_config(&config_path, &exe) {
         eprintln!(
             "[hook-installer] failed to patch {}: {}",
             config_path.display(),
@@ -502,29 +531,30 @@ fn write_aux_script(home: &Path, filename: &str, contents: &str) -> anyhow::Resu
     Ok(path)
 }
 
-/// Add a `notify = ["python", "<script>"]` line to ~/.codex/config.toml when
-/// safe. Three cases, matched in order:
+/// Add a `notify = ["<exe>", "__codex-notify"]` line to ~/.codex/config.toml
+/// when safe. Three cases, matched in order:
 ///   1. File doesn't exist or is empty → create it with our notify line.
-///   2. File contains a top-level notify already pointing at our script
-///      (any version of the path) → rewrite it to the current absolute path
-///      so an upgrade or moved $HOME doesn't break the hook.
+///   2. File contains a top-level notify already pointing at our forwarder
+///      (the native subcommand, or the legacy Python script) → rewrite it to
+///      the current absolute exe path so an upgrade or moved $HOME doesn't
+///      break the hook, and migrate the legacy Python form in place.
 ///   3. File contains a top-level notify pointing elsewhere → leave it alone
 ///      and log a warning. Never overwrite a user's custom notify command.
 ///
 /// "Top-level" means before the first `[section]` header. A `notify` entry
 /// inside a `[section]` is a different key entirely (e.g. `[mcp.notify]`)
 /// and we don't touch it.
-fn patch_codex_config(path: &Path, script_path: &Path) -> anyhow::Result<()> {
+fn patch_codex_config(path: &Path, exe: &Path) -> anyhow::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    let python_cmd = detect_python();
-    let script_str = script_path.display().to_string();
-    // TOML strings escape backslashes and quotes. Windows paths have plenty
-    // of backslashes — escape them so the resulting line parses cleanly.
-    let escaped = script_str.replace('\\', "\\\\").replace('"', "\\\"");
-    let new_line = format!("notify = [\"{}\", \"{}\"]", python_cmd, escaped);
+    let exe_str = exe.display().to_string();
+    // Codex execs the notify argv directly (no shell), so the raw path is
+    // correct. TOML strings escape backslashes and quotes — Windows paths
+    // have plenty of backslashes, so escape them to parse cleanly.
+    let escaped = exe_str.replace('\\', "\\\\").replace('"', "\\\"");
+    let new_line = format!("notify = [\"{}\", \"{}\"]", escaped, CODEX_NOTIFY_SUBCOMMAND);
 
     let existing = if path.exists() {
         fs::read_to_string(path).unwrap_or_default()
@@ -573,9 +603,11 @@ fn patch_codex_config(path: &Path, script_path: &Path) -> anyhow::Result<()> {
             fs::write(path, buf)?;
         }
         Some(idx) => {
-            // Is the existing notify pointing at us? Match by filename so
-            // we recover from $HOME moves and capitalization differences.
-            let points_at_us = top_level_notify_value.contains(CODEX_NOTIFY_FILENAME);
+            // Is the existing notify pointing at us? Match either the native
+            // subcommand (current form) or the legacy Python filename (so we
+            // migrate old installs in place), independent of $HOME / casing.
+            let points_at_us = top_level_notify_value.contains(CODEX_NOTIFY_SUBCOMMAND)
+                || top_level_notify_value.contains(CODEX_NOTIFY_FILENAME);
             if points_at_us {
                 let mut lines: Vec<String> =
                     existing.lines().map(|s| s.to_string()).collect();
@@ -598,7 +630,7 @@ fn patch_codex_config(path: &Path, script_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn patch_settings(path: &Path, script_path: &Path) -> anyhow::Result<()> {
+fn patch_settings(path: &Path, command: &str) -> anyhow::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -624,8 +656,6 @@ fn patch_settings(path: &Path, script_path: &Path) -> anyhow::Result<()> {
             .insert("hooks".into(), json!({}));
     }
 
-    let python_cmd = detect_python();
-    let command = format!("{} \"{}\"", python_cmd, script_path.display());
     let hook_cmd = json!({ "type": "command", "command": command });
 
     let hooks = root
@@ -663,20 +693,35 @@ fn is_coffee_entry(entry: &Value) -> bool {
             hs.iter().any(|h| {
                 h.get("command")
                     .and_then(|c| c.as_str())
-                    .map(|s| s.contains(SCRIPT_FILENAME))
+                    // Match the legacy Python command (so old entries get
+                    // migrated in place) and the native command, which is
+                    // `"<exe>" __hook` — i.e. `__hook` is the final argv
+                    // token. We check the LAST whitespace-delimited token
+                    // rather than a bare `contains("__hook")` so a user's own
+                    // hook whose command path merely *contains* "__hook"
+                    // (e.g. /home/u/.__hooks/lint.sh) is never misclassified
+                    // as ours and stripped.
+                    .map(|s| {
+                        s.contains(SCRIPT_FILENAME)
+                            || s.split_whitespace().last() == Some(HOOK_SUBCOMMAND)
+                    })
                     .unwrap_or(false)
             })
         })
         .unwrap_or(false)
 }
 
-fn detect_python() -> String {
-    // Windows: the `python` launcher (installed with Python.org and the MS
-    // Store build) resolves to Python 3. On Unix, prefer `python3` which is
-    // always the real 3.x interpreter.
-    if cfg!(target_os = "windows") {
-        "python".to_string()
+/// Build the Claude Code hook command: `"<exe>" __hook`. Claude runs
+/// shell-form hooks via Git Bash on Windows, where backslash paths are
+/// fragile — emit forward slashes there (Git Bash and CreateProcess both
+/// accept `C:/...`). Returns None only if `current_exe()` fails.
+fn claude_hook_command() -> Option<String> {
+    let exe = std::env::current_exe().ok()?;
+    let p = exe.display().to_string();
+    let p = if cfg!(target_os = "windows") {
+        p.replace('\\', "/")
     } else {
-        "python3".to_string()
-    }
+        p
+    };
+    Some(format!("\"{}\" {}", p, HOOK_SUBCOMMAND))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod terminal;
 mod server;
 mod hook_server;
+mod hook_forwarder;
 mod hook_installer;
 mod fs_watcher;
 mod tool_config;
@@ -14,6 +15,23 @@ mod git;
 use anyhow::Result;
 
 fn main() -> Result<()> {
+    // ── Native hook forwarder (fast path) ───────────────────────────────
+    // Invoked by Claude Code (`<exe> __hook`) and Codex (`<exe>
+    // __codex-notify <json>`) to forward agent status to the dynamic
+    // island. This MUST run before any GUI / Linux-backend / PATH-inherit
+    // setup below — the PATH fix spawns a login shell, which we don't want
+    // firing on every tool-call hook. Each arm calls process::exit and
+    // never returns. See hook_forwarder.rs for why this replaced the Python
+    // forwarders (no more `python`-not-found errors on Windows).
+    {
+        let argv: Vec<String> = std::env::args().collect();
+        match argv.get(1).map(|s| s.as_str()) {
+            Some("__hook") => hook_forwarder::run_claude_hook(),
+            Some("__codex-notify") => hook_forwarder::run_codex_notify(&argv),
+            _ => {}
+        }
+    }
+
     // ── Linux GUI backend selection ─────────────────────────────────────
     // Older WebKit2GTK (≤ 2.44) had a Wayland blank-window bug on
     // Ubuntu 24.04: WebView never paints, so the original workaround

--- a/src/server.rs
+++ b/src/server.rs
@@ -573,9 +573,54 @@ fn tier_terminal_start_blocking(
         },
 
         _ => if cfg!(target_os = "windows") {
-            ("powershell.exe".to_string(), vec!["-NoExit".to_string()])
+            // Prefer PowerShell 7 (`pwsh.exe`) when it's installed, falling
+            // back to Windows PowerShell 5.1 (`powershell.exe`). A user who
+            // installs pwsh expects Coffee CLI's terminal to use it rather
+            // than the bundled 5.1 (issue #51). Both accept `-NoExit`. Power
+            // users can still pin a specific shell via the `terminal` entry
+            // in ~/.coffee-cli/tools.json (handled just below).
+            let shell = if binary_on_path("pwsh.exe") {
+                "pwsh.exe"
+            } else {
+                "powershell.exe"
+            };
+            (shell.to_string(), vec!["-NoExit".to_string()])
         } else {
-            ("bash".to_string(), vec!["-l".to_string(), "-i".to_string()])
+            // Use the user's real login shell (`$SHELL`) rather than forcing
+            // bash: macOS has defaulted to zsh since Catalina, and Linux users
+            // often run zsh/fish. Falls back to bash if `$SHELL` is unset.
+            // (issue #51, Unix counterpart of the pwsh change above.)
+            let shell = std::env::var("SHELL")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                // Guard against a stale $SHELL (shell uninstalled / relocated)
+                // — spawning a missing path yields a dead tab, whereas bash is
+                // near-universal. Mirrors the binary_on_path() guard on the
+                // Windows pwsh path. $SHELL is virtually always absolute, so a
+                // plain existence check is enough and avoids a subprocess.
+                .filter(|s| std::path::Path::new(s).exists())
+                .unwrap_or_else(|| "bash".to_string());
+            let basename = std::path::Path::new(&shell)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("");
+            let mut args = vec!["-l".to_string(), "-i".to_string()];
+            // OSC 7 cwd reporting drives the left workspace tree's cd-follow.
+            // bash gets it via PROMPT_COMMAND (injected in terminal.rs); fish
+            // ignores PROMPT_COMMAND, so inject an equivalent `--on-variable
+            // PWD` hook via fish's `-C` init-command (emits the same
+            // `file://<host><pwd>` shape extract_osc7_cwd parses, and fires
+            // once for the initial dir). zsh has no clean env/flag hook, so it
+            // forgoes auto cd-follow — users can still navigate the tree
+            // manually, and a specific shell can be pinned via tools.json.
+            if basename == "fish" {
+                args.push("-C".to_string());
+                args.push(
+                    r#"function __coffee_osc7 --on-variable PWD; printf '\033]7;file://%s%s\033\\' (hostname) "$PWD"; end; __coffee_osc7"#
+                        .to_string(),
+                );
+            }
+            (shell, args)
         }
     };
 

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Coffee CLI",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "identifier": "com.coffeecli.desktop",
   "build": {
     "frontendDist": "./src-ui/dist",


### PR DESCRIPTION
## v2.9.3

### Native hook forwarder (no more Python)
Replaces the Python hook scripts with a native subcommand built into the binary (`<exe> __hook` reads stdin, `<exe> __codex-notify <json>` reads argv — see `src/hook_forwarder.rs`). Fixes the `UserPromptSubmit hook error / Python was not found` that Claude Code surfaced on every prompt on Windows machines without Python. `hook_installer` registers the native command, migrates old python entries in place, and matches our own entries by the trailing `__hook` argv token (not a bare substring, so a user's own hook can't be stripped).

### Terminal default shell (#51)
- **Windows:** prefer PowerShell 7 (`pwsh`) when installed, fall back to 5.1.
- **macOS / Linux:** follow `$SHELL` instead of forcing bash (fish keeps cd-follow via a `-C` OSC7 hook; falls back to bash if `$SHELL` is missing).
- Power users can still pin a specific shell via `~/.coffee-cli/tools.json`.

### UI
- Swap the 'open library' gear for a 2x2 app-grid icon so it no longer collides with the settings gear.

### Release
- Bump version 2.9.2 → 2.9.3 + 5-language release notes.

Reviewed: final holistic review clean (no CRITICAL/HIGH); the two real bugs found during review (is_coffee_entry collision, $SHELL existence guard) were fixed. Closes #51.