### PR TITLE
chore: remove reserved hidden account header from right panel

### DIFF
--- a/src-ui/src/components/right/TaskBoard.tsx
+++ b/src-ui/src/components/right/TaskBoard.tsx
@@ -550,18 +550,6 @@ export function TaskBoard() {
 
   return (
     <div className={`task-board${__IS_LINUX__ ? ' task-board--static' : ''}`}>
-      {/* ── User Profile Header (Hidden for now, planned for next version) ── */}
-      <div className="panel-header" style={{ visibility: 'hidden', height: 0, minHeight: 0, padding: 0, overflow: 'hidden' }}>
-        <div className="brand">
-          <img src="https://i.pravatar.cc/150?u=a042581f4e29026024d" alt="avatar" style={{ width: 24, height: 24, borderRadius: '50%' }} />
-          <span>Eben</span>
-        </div>
-        <div className="header-actions">
-          <div className="icon-btn xs"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg></div>
-          <div className="icon-btn xs"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" /><path d="M13.73 21a2 2 0 0 1-3.46 0" /></svg></div>
-        </div>
-      </div>
-
       {/* ── Tabs Header ── */}
       <div className="right-tabs" style={{ position: 'relative' }}>
         <button className={`right-tab ${activeTab === 'tasks' ? 'active' : ''}`} onClick={() => setActiveTab('tasks')}>


### PR DESCRIPTION
Deletes the long-hidden 'User Profile Header' placeholder (Eben avatar + gear/bell) from the right TaskBoard. The account UI now lives in the bottom-left (carried forward on `feat/account`), so this reservation is obsolete. Also removes the external `i.pravatar.cc` avatar request the hidden block fired on every launch (visibility:hidden doesn't stop `<img>` loading).