### PR TITLE
fix(terminal): CJK font fallback for the xterm font stack

### DIFF
--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -363,11 +363,18 @@ function TierTerminalImpl({
     // installed one — which oh-my-posh's setup explicitly tells them to do —
     // automatically get the missing glyphs without us bundling a 5 MB font.
     const NERD_FONTS = "'CaskaydiaCove Nerd Font', 'JetBrainsMono Nerd Font', 'MesloLGS NF', 'FiraCode Nerd Font', 'Hack Nerd Font'";
+    // CJK fallback — the Latin mono faces above carry NO Chinese/Japanese/
+    // Korean glyphs, so without this the WebView picks a per-machine default
+    // CJK face (nice 微软雅黑 on one box, ugly 宋体 / a JP serif on another).
+    // One cross-platform cascade (Mac → Windows → Linux faces); the browser
+    // skips names absent on the host, so the right OS face wins everywhere.
+    // Mirrors the UI's --font CJK stack (global.css) for visual consistency.
+    const CJK = "'PingFang SC', 'PingFang TC', 'Hiragino Sans', 'Apple SD Gothic Neo', 'Microsoft YaHei', 'Microsoft JhengHei', 'Yu Gothic UI', 'Malgun Gothic', 'Noto Sans CJK SC', 'Noto Sans CJK TC', 'Noto Sans CJK JP', 'Noto Sans CJK KR', 'WenQuanYi Micro Hei'";
     const fontFamily = isLinux
-      ? `CascadiaMono, ${NERD_FONTS}, 'Ubuntu Mono', 'Noto Sans Mono', 'DejaVu Sans Mono', 'Liberation Mono', monospace`
+      ? `CascadiaMono, ${NERD_FONTS}, 'Ubuntu Mono', 'Noto Sans Mono', 'DejaVu Sans Mono', 'Liberation Mono', ${CJK}, monospace`
       : isMac
-        ? `CascadiaMono, ${NERD_FONTS}, ui-monospace, Menlo, Monaco, 'Courier New', monospace`
-        : `CascadiaMono, ${NERD_FONTS}, 'Cascadia Mono', Consolas, 'Courier New', monospace`;
+        ? `CascadiaMono, ${NERD_FONTS}, ui-monospace, Menlo, Monaco, 'Courier New', ${CJK}, monospace`
+        : `CascadiaMono, ${NERD_FONTS}, 'Cascadia Mono', Consolas, 'Courier New', ${CJK}, monospace`;
     const term = new Terminal({
       fontFamily,
       fontSize: 14,


### PR DESCRIPTION
The terminal `fontFamily` only listed Latin monospace faces, so CJK glyphs fell through to a per-machine default face (微软雅黑 on one box, 宋体 / a JP serif on another). Appends a cross-platform CJK cascade (PingFang/Hiragino/Apple SD Gothic → YaHei/JhengHei/Yu Gothic/Malgun → Noto CJK/WenQuanYi) before generic `monospace`, mirroring the UI `--font` stack. Per-glyph fallback keeps Latin on CascadiaMono — only CJK glyphs hit the new faces, so alignment is unchanged and rendering is consistent across machines/locales. Covers zh-CN / zh-TW / ja / ko.