### PR TITLE
feat(tasks): 便签式 sticky-note task board view

### DIFF
--- a/src-ui/src/components/common/SettingsModal.css
+++ b/src-ui/src/components/common/SettingsModal.css
@@ -315,6 +315,17 @@
 .settings-key-card.active kbd { border-color: color-mix(in srgb, var(--accent, #c4956a) 50%, transparent); }
 .settings-key-sub { font-size: 11px; color: var(--text-3, rgba(255, 255, 255, 0.45)); }
 
+/* ── Task view cards (To-do list vs Sticky notes) ──────────────────────── */
+.settings-taskview-card { flex: 1; min-width: 180px; }
+.settings-taskview-icon {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  color: var(--accent, #c4956a);
+}
+.settings-taskview-icon svg { width: 100%; height: 100%; }
+.settings-taskview-label { font-size: 13px; font-weight: 600; color: var(--text-1, #fff); }
+
 /* ── Language list ─────────────────────────────────────────────────────── */
 .settings-lang-list {
   display: grid;

--- a/src-ui/src/components/common/SettingsModal.tsx
+++ b/src-ui/src/components/common/SettingsModal.tsx
@@ -19,10 +19,26 @@ import { IS_MACOS } from '../../lib/platform';
 import { TERM_COLOR_SCHEMES } from '../center/TierTerminal';
 import { commands, type FontInfo } from '../../tauri';
 import { FontPicker } from './FontPicker';
-import { THEME_COLORS, THEME_SHAPES, ICON_ART_THEMES, LANGUAGES, isMaskTintTheme } from '../../lib/personalization';
+import { THEME_COLORS, THEME_SHAPES, ICON_ART_THEMES, LANGUAGES, TASK_VIEW_MODES, isMaskTintTheme } from '../../lib/personalization';
 import './SettingsModal.css';
 
-type Section = 'appearance' | 'wallpaper' | 'terminal' | 'gambit' | 'language';
+type Section = 'appearance' | 'wallpaper' | 'terminal' | 'gambit' | 'tasks' | 'language';
+
+// Per-mode preview glyphs for the Tasks section (checklist vs sticky note).
+const TASK_VIEW_ICONS: Record<'list' | 'note', ReactNode> = {
+  list: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M9 6h11" /><path d="M9 12h11" /><path d="M9 18h11" />
+      <path d="m3 6 1 1 2-2" /><path d="m3 12 1 1 2-2" /><circle cx="4" cy="18" r="1" />
+    </svg>
+  ),
+  note: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M15.5 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10l6-6V5a2 2 0 0 0-2-2Z" />
+      <path d="M15 21v-5a1 1 0 0 1 1-1h5" />
+    </svg>
+  ),
+};
 
 const ICONS: Record<Section, ReactNode> = {
   appearance: (
@@ -46,6 +62,12 @@ const ICONS: Record<Section, ReactNode> = {
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
       <rect width="20" height="16" x="2" y="4" rx="2" />
       <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10" />
+    </svg>
+  ),
+  tasks: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M11 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6" />
+      <path d="m9 11 3 3L22 4" />
     </svg>
   ),
   language: (
@@ -139,6 +161,7 @@ export function SettingsModal() {
     dispatch({ type: 'SET_TERM_FONT', font: clean });
   };
   const setOpacity = (n: number) => dispatch({ type: 'SET_WALLPAPER_OPACITY', opacity: n });
+  const setTaskView = (mode: 'list' | 'note') => dispatch({ type: 'SET_TASK_VIEW_MODE', mode });
   const setEnterToSend = (value: boolean) => {
     dispatch({ type: 'SET_GAMBIT_ENTER_TO_SEND', value });
     try { localStorage.setItem('cc-gambit-enter-send', String(value)); } catch {}
@@ -152,6 +175,7 @@ export function SettingsModal() {
     { id: 'wallpaper',  label: t('settings.wallpaper' as any) },
     { id: 'terminal',   label: t('settings.terminal' as any) },
     { id: 'gambit',     label: t('settings.gambit' as any) },
+    { id: 'tasks',      label: t('settings.tasks' as any) },
     { id: 'language',   label: t('settings.language' as any) },
   ];
   const currentLabel = SECTIONS.find(s => s.id === section)?.label ?? '';
@@ -337,6 +361,31 @@ export function SettingsModal() {
                     <span className="settings-key-combo"><kbd>{modKey}</kbd><span className="settings-key-plus">+</span><kbd>Enter</kbd></span>
                     <span className="settings-key-sub">Enter {t('settings.send.newline' as any)}</span>
                   </button>
+                </div>
+              </>
+            )}
+
+            {section === 'tasks' && (
+              <>
+                <div className="settings-section-label">{t('settings.tasks.view' as any)}</div>
+                <div className="settings-key-row">
+                  {TASK_VIEW_MODES.map(m => {
+                    const active = state.taskViewMode === m.code;
+                    return (
+                      <button
+                        key={m.code}
+                        className={`settings-key-card settings-taskview-card${active ? ' active' : ''}`}
+                        onClick={() => setTaskView(m.code)}
+                        aria-pressed={active}
+                      >
+                        <span className="settings-key-combo">
+                          <span className="settings-taskview-icon">{TASK_VIEW_ICONS[m.code]}</span>
+                          <span className="settings-taskview-label">{t(m.labelKey as any)}</span>
+                        </span>
+                        <span className="settings-key-sub">{t(m.subKey as any)}</span>
+                      </button>
+                    );
+                  })}
                 </div>
               </>
             )}

--- a/src-ui/src/components/right/TaskBoard.tsx
+++ b/src-ui/src/components/right/TaskBoard.tsx
@@ -1,23 +1,13 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import type { ReactNode } from 'react';
 import { useT } from '../../i18n/useT';
 import { useAppState } from '../../store/app-state';
 import { isTauri, commands } from '../../tauri';
 import { getTabActions } from '../../lib/tab-actions';
 import './TaskBoard.css';
 import { ChangesBoard } from './ChangesBoard';
-
-// ─── Types ───────────────────────────────────────────────────────────────────
-
-type TaskStatus = 'todo' | 'working' | 'done';
-
-interface TaskItem {
-  id: string;
-  title: string;
-  description?: string;
-  status: TaskStatus;
-  createdAt: number;
-}
+import { TaskNoteView } from './TaskNoteView';
+import { TaskEmptyState } from './TaskEmptyState';
+import { NEXT_STATUS, STATUS_ORDER, type TaskItem, type TaskStatus } from './task-types';
 
 // ─── Persistence (Rust file backend with localStorage fallback) ──────────────
 
@@ -70,13 +60,6 @@ function saveTasksToBackend(tasks: TaskItem[]) {
   }
 }
 
-const NEXT_STATUS: Record<TaskStatus, TaskStatus> = {
-  todo: 'working',
-  working: 'done',
-  done: 'todo',
-};
-
-const STATUS_ORDER: TaskStatus[] = ['working', 'todo', 'done'];
 const SECTION_LABEL_KEYS: Record<TaskStatus, 'task.section.working' | 'task.section.todo' | 'task.section.done'> = {
   working: 'task.section.working',
   todo: 'task.section.todo',
@@ -88,7 +71,7 @@ const SECTION_LABEL_KEYS: Record<TaskStatus, 'task.section.working' | 'task.sect
 export function TaskBoard() {
   const t = useT();
   const { state } = useAppState();
-  const isZh = state.currentLang.startsWith('zh');
+  const viewMode = state.taskViewMode;
   const [tasks, setTasks] = useState<TaskItem[]>([]);
   const [removingId, setRemovingId] = useState<string | null>(null);
   const [addingId, setAddingId] = useState<string | null>(null);
@@ -254,6 +237,18 @@ export function TaskBoard() {
 
   const handleToggle = useCallback((id: string) => {
     setTasks(prev => prev.map(t => t.id === id ? { ...t, status: NEXT_STATUS[t.status] } : t));
+  }, []);
+
+  // Direct status set — used by the note view's traffic-light dots (the list
+  // view's checkbox cycles via handleToggle instead). Card auto-regroups.
+  const setStatus = useCallback((id: string, status: TaskStatus) => {
+    setTasks(prev => prev.map(t => t.id === id ? { ...t, status } : t));
+  }, []);
+
+  // Live title edit — the note body is always-editable (no commit step), so it
+  // writes through on every keystroke. Empty is allowed while typing.
+  const updateTitle = useCallback((id: string, title: string) => {
+    setTasks(prev => prev.map(t => t.id === id ? { ...t, title } : t));
   }, []);
 
   const handleRemove = useCallback((id: string) => {
@@ -562,7 +557,19 @@ export function TaskBoard() {
 
       {activeTab === 'tasks' && (
         <>
-          {/* ── Task List ── */}
+          {viewMode === 'note' ? (
+            <TaskNoteView
+              tasks={tasks}
+              addingId={addingId}
+              removingId={removingId}
+              canSend={!!state.activeTerminalId}
+              onSetStatus={setStatus}
+              onUpdateTitle={updateTitle}
+              onRemove={handleRemove}
+              onSend={sendToAgent}
+              onReorder={setTasks}
+            />
+          ) : (
           <div ref={listRef} className="task-list" style={{ paddingBottom: '80px' }}>
         {STATUS_ORDER.map(status => {
           const sectionTasks = tasks.filter(t => t.status === status);
@@ -728,47 +735,9 @@ export function TaskBoard() {
           );
         })}
 
-        {tasks.length === 0 && (() => {
-          const hour = new Date().getHours();
-          let greeting: string;
-          let icon: ReactNode;
-
-          const sunIcon = (
-            <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--accent)' }}>
-              <circle cx="12" cy="12" r="4"/>
-              <path d="M12 2v2"/><path d="M12 20v2"/>
-              <path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/>
-              <path d="M2 12h2"/><path d="M20 12h2"/>
-              <path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>
-            </svg>
-          );
-          const moonIcon = (
-            <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--accent)' }}>
-              <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
-            </svg>
-          );
-
-          if (hour >= 5 && hour < 12) {
-            greeting = t('task.greeting.morning');
-            icon = sunIcon;
-          } else if (hour >= 12 && hour < 18) {
-            greeting = t('task.greeting.afternoon');
-            icon = sunIcon;
-          } else {
-            greeting = t('task.greeting.evening');
-            icon = moonIcon;
-          }
-
-          return (
-            <div className="task-empty">
-              <div className="task-empty-icon">{icon}</div>
-              <div className="task-empty-text"
-                style={isZh ? { fontFamily: 'var(--font, system-ui)', fontStyle: 'normal', fontWeight: 400, letterSpacing: '0.08em' } : undefined}
-              >{greeting}</div>
-            </div>
-          );
-        })()}
+        {tasks.length === 0 && <TaskEmptyState />}
       </div>
+          )}
 
       {/* ── Floating Action Button (FAB) ── */}
       <div className="task-fab-container">

--- a/src-ui/src/components/right/TaskEmptyState.tsx
+++ b/src-ui/src/components/right/TaskEmptyState.tsx
@@ -1,0 +1,56 @@
+// Empty-state greeting for the task board — shared by both the to-do list
+// view and the sticky-note view. Time-of-day aware (sun/moon + greeting).
+// Extracted from TaskBoard so the two views render an identical empty state
+// without duplicating the IIFE.
+
+import type { ReactNode } from 'react';
+import { useT } from '../../i18n/useT';
+import { useAppState } from '../../store/app-state';
+
+export function TaskEmptyState() {
+  const t = useT();
+  const { state } = useAppState();
+  const isZh = state.currentLang.startsWith('zh');
+
+  const hour = new Date().getHours();
+  let greeting: string;
+  let icon: ReactNode;
+
+  const sunIcon = (
+    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--accent)' }}>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2" /><path d="M12 20v2" />
+      <path d="m4.93 4.93 1.41 1.41" /><path d="m17.66 17.66 1.41 1.41" />
+      <path d="M2 12h2" /><path d="M20 12h2" />
+      <path d="m6.34 17.66-1.41 1.41" /><path d="m19.07 4.93-1.41 1.41" />
+    </svg>
+  );
+  const moonIcon = (
+    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--accent)' }}>
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </svg>
+  );
+
+  if (hour >= 5 && hour < 12) {
+    greeting = t('task.greeting.morning');
+    icon = sunIcon;
+  } else if (hour >= 12 && hour < 18) {
+    greeting = t('task.greeting.afternoon');
+    icon = sunIcon;
+  } else {
+    greeting = t('task.greeting.evening');
+    icon = moonIcon;
+  }
+
+  return (
+    <div className="task-empty">
+      <div className="task-empty-icon">{icon}</div>
+      <div
+        className="task-empty-text"
+        style={isZh ? { fontFamily: 'var(--font, system-ui)', fontStyle: 'normal', fontWeight: 400, letterSpacing: '0.08em' } : undefined}
+      >
+        {greeting}
+      </div>
+    </div>
+  );
+}

--- a/src-ui/src/components/right/TaskNoteView.css
+++ b/src-ui/src/components/right/TaskNoteView.css
@@ -1,0 +1,228 @@
+/* TaskNoteView.css — sticky-note presentation of the task board. */
+
+.task-note-list {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  /* Top padding gives the first card's drop-before indicator (top: -6px) room
+     inside the scroll viewport — without it, reordering to the very top shows
+     no line. Bottom padding clears the floating add button. */
+  padding: 6px 0 80px;
+  /* Scrollbar hidden via global rule in styles/global.css. */
+}
+
+.task-note-list--empty {
+  padding-bottom: 0;
+}
+
+/* ─── Note card ─────────────────────────────────────────────────────────────── */
+
+.task-note-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 11px 12px 12px;
+  border-radius: var(--radius-md, 12px);
+  background: rgba(255, 255, 255, 0.035);
+  /* Quiet status tint on the leading edge — reinforces the active dot without
+     shouting. Colour set per status class below. */
+  border-left: 3px solid transparent;
+  transition: background-color 0.2s, opacity 0.25s, transform 0.18s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.task-note-card:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.task-note-card.status-working { border-left-color: color-mix(in srgb, #ff5f57 55%, transparent); }
+.task-note-card.status-todo    { border-left-color: color-mix(in srgb, #febc2e 50%, transparent); }
+.task-note-card.status-done    { border-left-color: color-mix(in srgb, #28c840 45%, transparent); opacity: 0.55; }
+
+.task-note-card.status-done:hover { opacity: 0.8; }
+
+/* Dragged card collapses to a faint placeholder; the floating ghost carries
+   the visible card. */
+.task-note-card.dragging {
+  opacity: 0.25;
+}
+
+/* Exit animation — fades + slides out during the parent's 300ms removal window
+   (matches the to-do list's removal feel). */
+.task-note-card.removing {
+  animation: task-note-out 0.28s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  pointer-events: none;
+}
+
+@keyframes task-note-out {
+  to {
+    opacity: 0;
+    transform: translateX(28px) scale(0.97);
+  }
+}
+
+/* Drop indicator — a 2px accent line at the edge the card would insert against. */
+.task-note-card.drop-before::before,
+.task-note-card.drop-after::after {
+  content: '';
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--accent, #c4956a);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 50%, transparent);
+}
+.task-note-card.drop-before::before { top: -6px; }
+.task-note-card.drop-after::after { bottom: -6px; }
+
+/* ─── Head row: dots · timestamp · actions ──────────────────────────────────── */
+
+.task-note-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.task-note-dots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.task-note-dot {
+  width: 11px;
+  height: 11px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  flex-shrink: 0;
+  cursor: pointer;
+  /* Faint tint of the dot's own colour when inactive, so all three read as a
+     red/amber/green traffic light; the active one goes full-colour. */
+  background: color-mix(in srgb, var(--dot) 24%, transparent);
+  transition: background 0.15s, box-shadow 0.15s, transform 0.15s;
+}
+
+.task-note-dot:hover {
+  background: color-mix(in srgb, var(--dot) 55%, transparent);
+  transform: scale(1.1);
+}
+
+.task-note-dot.active {
+  background: var(--dot);
+  /* Static halo — no animation, safe on WebKit2GTK (Linux). */
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--dot) 18%, transparent);
+}
+
+.task-note-time {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  margin-left: auto;
+  font-family: var(--font, system-ui);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--text-3, rgba(255, 255, 255, 0.4));
+  white-space: nowrap;
+  user-select: none;
+}
+
+.task-note-clock {
+  color: var(--text-2, rgba(255, 255, 255, 0.6));
+  font-variant-numeric: tabular-nums;
+}
+
+.task-note-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.task-note-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-xs, 6px);
+  background: transparent;
+  color: var(--accent, #c4956a);
+  cursor: pointer;
+  /* Calm at rest; revealed on card hover (mirrors the list view's action
+     slots) so the resting card stays clean. */
+  opacity: 0;
+  transition: opacity 0.15s, filter 0.15s, background 0.15s;
+}
+
+.task-note-card:hover .task-note-btn {
+  opacity: 0.85;
+}
+
+.task-note-btn:hover:not(:disabled) {
+  opacity: 1;
+  filter: brightness(1.25);
+}
+
+.task-note-send:disabled {
+  opacity: 0;
+  cursor: not-allowed;
+}
+.task-note-card:hover .task-note-send:disabled {
+  opacity: 0.25;
+}
+
+/* ─── Note body ─────────────────────────────────────────────────────────────── */
+
+.task-note-body {
+  width: 100%;
+  min-height: 56px;
+  resize: none;
+  overflow: hidden;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text-1, #e8e4de);
+  font-family: var(--font, system-ui);
+  font-size: 13.5px;
+  line-height: 1.55;
+  padding: 2px 2px 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  box-sizing: border-box;
+}
+
+.task-note-body::placeholder {
+  color: var(--text-3, rgba(255, 255, 255, 0.3));
+}
+
+.task-note-card.status-done .task-note-body {
+  color: var(--text-2, rgba(255, 255, 255, 0.55));
+}
+
+/* ─── Floating ghost (drag clone) ───────────────────────────────────────────── */
+
+.task-note-card-ghost {
+  position: fixed;
+  z-index: 99999;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 11px 12px 12px;
+  border-radius: var(--radius-md, 12px);
+  background: var(--bg-panel, rgba(40, 40, 42, 0.98));
+  border: 1px solid var(--accent, #c4956a);
+  box-shadow: 0 20px 30px -8px rgba(0, 0, 0, 0.5), 0 8px 12px -4px rgba(0, 0, 0, 0.3);
+  transform: scale(1.02);
+  opacity: 0.96;
+  overflow: hidden;
+}

--- a/src-ui/src/components/right/TaskNoteView.tsx
+++ b/src-ui/src/components/right/TaskNoteView.tsx
@@ -1,0 +1,308 @@
+// TaskNoteView — sticky-note presentation of the task board. Same TaskItem
+// data as the to-do list (TaskBoard owns the state and passes it down); this
+// view just renders each task as a roomy note card:
+//
+//   ┌─────────────────────────────────────────────┐
+//   │ ● ● ●            2026.6.28  21:48   🗑  ▶     │   ← traffic-light status
+//   │                                               │     dots + timestamp
+//   │  (big editable note body — write freely)      │
+//   └─────────────────────────────────────────────┘
+//
+// The three dots ARE the status picker (红=进行中 / 黄=待办 / 绿=已完成); clicking
+// one sets the status and the card auto-sorts into that group (working → todo →
+// done), exactly like the list view's section order. Cards can be dragged
+// up/down to reorder within their group. The note body edits `title` (single
+// roomy field — the whole point is escaping the cramped inline input); the
+// list view's `description` field is preserved but not surfaced here.
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useT } from '../../i18n/useT';
+import { TaskEmptyState } from './TaskEmptyState';
+import { STATUS_ORDER, type TaskItem, type TaskStatus } from './task-types';
+import './TaskNoteView.css';
+
+// Traffic-light dots, top-to-bottom priority. Colors are deliberately the
+// literal macOS-window red/amber/green from the user's mockup, not the theme
+// accent — the three-light metaphor only reads if the colors are fixed.
+const STATUS_DOTS: { status: TaskStatus; color: string }[] = [
+  { status: 'working', color: '#ff5f57' },
+  { status: 'todo', color: '#febc2e' },
+  { status: 'done', color: '#28c840' },
+];
+
+function formatNoteTime(ts: number): { date: string; time: string } {
+  const d = new Date(ts);
+  const date = `${d.getFullYear()}.${d.getMonth() + 1}.${d.getDate()}`;
+  const time = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  return { date, time };
+}
+
+interface DropLine {
+  id: string;
+  position: 'before' | 'after';
+}
+
+interface TaskNoteViewProps {
+  tasks: TaskItem[];
+  // The task most recently added via the FAB — its note body auto-focuses so
+  // the user can start typing immediately (mirrors the list view's inline edit).
+  addingId: string | null;
+  // The task mid-removal — kept rendered for one exit animation before the
+  // parent drops it from the array (shared 300ms window with the list view).
+  removingId: string | null;
+  canSend: boolean;
+  onSetStatus: (id: string, status: TaskStatus) => void;
+  onUpdateTitle: (id: string, title: string) => void;
+  onRemove: (id: string) => void;
+  onSend: (task: TaskItem) => void;
+  // Functional updater (the parent's setTasks) so a reorder computed at drop
+  // time still composes against the freshest array — guards against a
+  // multi-window sync landing mid-drag.
+  onReorder: (updater: (prev: TaskItem[]) => TaskItem[]) => void;
+}
+
+export function TaskNoteView({
+  tasks, addingId, removingId, canSend, onSetStatus, onUpdateTitle, onRemove, onSend, onReorder,
+}: TaskNoteViewProps) {
+  const t = useT();
+
+  // Display order: grouped by status (working → todo → done). The array order
+  // within each status group is preserved, so drag-reordering the underlying
+  // array reorders same-status cards; cross-status drags simply regroup.
+  const ordered = STATUS_ORDER.flatMap(s => tasks.filter(task => task.status === s));
+
+  // ── Drag (refs to avoid stale closures, mirrors TaskBoard's approach) ──
+  const listRef = useRef<HTMLDivElement>(null);
+  const ghostRef = useRef<HTMLDivElement | null>(null);
+  const dragStartedRef = useRef(false);
+  const dropTargetRef = useRef<DropLine | null>(null);
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [dropLine, setDropLine] = useState<DropLine | null>(null);
+
+  const handlePointerDown = (e: React.PointerEvent, id: string) => {
+    const target = e.target as HTMLElement;
+    // Never start a drag from an interactive control — the note body needs
+    // click-to-place-caret + text selection, and the dots/buttons need clicks.
+    if (target.closest('textarea') || target.closest('button')) return;
+
+    const cardEl = target.closest('.task-note-card') as HTMLElement;
+    if (!cardEl) return;
+
+    const rect = cardEl.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    const offsetY = e.clientY - rect.top;
+    const startX = e.clientX;
+    const startY = e.clientY;
+    dragStartedRef.current = false;
+    dropTargetRef.current = null;
+
+    const THRESHOLD = 6;
+
+    const onMove = (me: PointerEvent) => {
+      if (!dragStartedRef.current) {
+        if (Math.abs(me.clientX - startX) < THRESHOLD && Math.abs(me.clientY - startY) < THRESHOLD) return;
+        dragStartedRef.current = true;
+        setDragId(id);
+        const ghost = cardEl.cloneNode(true) as HTMLDivElement;
+        ghost.className = 'task-note-card-ghost';
+        // cloneNode copies DOM attributes but not the live textarea `.value`
+        // (React drives it as a property), so the clone's note body would be
+        // blank. Copy it across so the drag preview keeps the user's text.
+        const srcBody = cardEl.querySelector('textarea');
+        const ghostBody = ghost.querySelector('textarea');
+        if (srcBody && ghostBody) ghostBody.value = srcBody.value;
+        ghost.style.width = `${rect.width}px`;
+        ghost.style.left = `${me.clientX - offsetX}px`;
+        ghost.style.top = `${me.clientY - offsetY}px`;
+        document.body.appendChild(ghost);
+        ghostRef.current = ghost;
+      }
+
+      if (ghostRef.current) {
+        ghostRef.current.style.left = `${me.clientX - offsetX}px`;
+        ghostRef.current.style.top = `${me.clientY - offsetY}px`;
+      }
+
+      if (!listRef.current) return;
+      const cards = listRef.current.querySelectorAll<HTMLElement>('[data-note-id]');
+      let next: DropLine | null = null;
+      for (const card of cards) {
+        const cid = card.dataset.noteId!;
+        if (cid === id) continue;
+        const r = card.getBoundingClientRect();
+        if (me.clientY >= r.top && me.clientY < r.bottom) {
+          next = { id: cid, position: me.clientY < r.top + r.height / 2 ? 'before' : 'after' };
+          break;
+        }
+      }
+      dropTargetRef.current = next;
+      // Only re-render the indicator when the target actually changes.
+      setDropLine(prev =>
+        prev?.id === next?.id && prev?.position === next?.position ? prev : next
+      );
+    };
+
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      if (ghostRef.current) { ghostRef.current.remove(); ghostRef.current = null; }
+
+      const drop = dropTargetRef.current;
+      if (dragStartedRef.current && drop && drop.id !== id) {
+        onReorder(prev => {
+          const dragged = prev.find(task => task.id === id);
+          const target = prev.find(task => task.id === drop.id);
+          if (!dragged || !target) return prev;
+          // Dropping onto a different-status card adopts that card's status, so
+          // dragging across the red/amber/green groups re-files the note (same
+          // outcome as clicking its dot) instead of snapping back to its old
+          // group. Same-status drags just reorder within the group.
+          const moved = dragged.status === target.status
+            ? dragged
+            : { ...dragged, status: target.status };
+          const without = prev.filter(task => task.id !== id);
+          const targetIdx = without.findIndex(task => task.id === drop.id);
+          if (targetIdx === -1) return prev;
+          const insertAt = drop.position === 'before' ? targetIdx : targetIdx + 1;
+          without.splice(insertAt, 0, moved);
+          return without;
+        });
+      }
+
+      setDragId(null);
+      setDropLine(null);
+      dropTargetRef.current = null;
+      dragStartedRef.current = false;
+    };
+
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+
+  if (ordered.length === 0) {
+    return (
+      <div className="task-note-list task-note-list--empty">
+        <TaskEmptyState />
+      </div>
+    );
+  }
+
+  return (
+    <div ref={listRef} className="task-note-list">
+      {ordered.map(task => {
+        const { date, time } = formatNoteTime(task.createdAt);
+        const line = dropLine?.id === task.id ? dropLine.position : null;
+        return (
+          <div
+            key={task.id}
+            data-note-id={task.id}
+            data-status={task.status}
+            className={[
+              'task-note-card',
+              `status-${task.status}`,
+              dragId === task.id && 'dragging',
+              removingId === task.id && 'removing',
+              line === 'before' && 'drop-before',
+              line === 'after' && 'drop-after',
+            ].filter(Boolean).join(' ')}
+            style={{ touchAction: 'none' }}
+            onPointerDown={e => handlePointerDown(e, task.id)}
+          >
+            <div className="task-note-head">
+              <div className="task-note-dots" role="group">
+                {STATUS_DOTS.map(d => (
+                  <button
+                    key={d.status}
+                    type="button"
+                    className={`task-note-dot${task.status === d.status ? ' active' : ''}`}
+                    style={{ ['--dot' as string]: d.color }}
+                    onClick={() => onSetStatus(task.id, d.status)}
+                    aria-pressed={task.status === d.status}
+                  />
+                ))}
+              </div>
+
+              <div className="task-note-time">
+                <span className="task-note-date">{date}</span>
+                <span className="task-note-clock">{time}</span>
+              </div>
+
+              <div className="task-note-actions">
+                <button
+                  type="button"
+                  className="task-note-btn task-note-delete"
+                  onClick={() => onRemove(task.id)}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="3 6 5 6 21 6" />
+                    <path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6" />
+                    <path d="M10 11v6" /><path d="M14 11v6" />
+                    <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
+                  </svg>
+                </button>
+                <button
+                  type="button"
+                  className="task-note-btn task-note-send"
+                  onClick={() => onSend(task)}
+                  disabled={!canSend || !task.title.trim()}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                    <polygon points="5 3 21 12 5 21" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
+            <NoteBody
+              value={task.title}
+              autoFocus={addingId === task.id}
+              placeholder={t('task.note_placeholder')}
+              onChange={next => onUpdateTitle(task.id, next)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Note body — auto-growing textarea ───────────────────────────────────────
+// Its own component so the grow-to-fit layout effect can key on this card's
+// value without a shared ref map across the mapped list.
+
+interface NoteBodyProps {
+  value: string;
+  autoFocus: boolean;
+  placeholder: string;
+  onChange: (next: string) => void;
+}
+
+function NoteBody({ value, autoFocus, placeholder, onChange }: NoteBodyProps) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, [value]);
+
+  useEffect(() => {
+    if (autoFocus && ref.current) {
+      ref.current.focus();
+      ref.current.select();
+    }
+  }, [autoFocus]);
+
+  return (
+    <textarea
+      ref={ref}
+      className="task-note-body"
+      value={value}
+      placeholder={placeholder}
+      rows={2}
+      onChange={e => onChange(e.target.value)}
+      onPointerDown={e => e.stopPropagation()}
+    />
+  );
+}

--- a/src-ui/src/components/right/task-types.ts
+++ b/src-ui/src/components/right/task-types.ts
@@ -1,0 +1,26 @@
+// Shared task model — consumed by both the to-do list view (TaskBoard) and
+// the sticky-note view (TaskNoteView). Kept in its own module so the two
+// views import the same types/constants without a circular runtime import
+// (TaskBoard imports the TaskNoteView component; both import from here).
+
+export type TaskStatus = 'todo' | 'working' | 'done';
+
+export interface TaskItem {
+  id: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  createdAt: number;
+}
+
+// Click-to-advance order for the to-do checkbox (todo → working → done → todo).
+export const NEXT_STATUS: Record<TaskStatus, TaskStatus> = {
+  todo: 'working',
+  working: 'done',
+  done: 'todo',
+};
+
+// Vertical grouping order shared by both views: 进行中 (top) → 待办 → 已完成.
+// The sticky-note view renders this same order with no section headers — the
+// per-card status dots carry the grouping signal instead.
+export const STATUS_ORDER: TaskStatus[] = ['working', 'todo', 'done'];

--- a/src-ui/src/i18n/de.ts
+++ b/src-ui/src/i18n/de.ts
@@ -104,6 +104,13 @@ export const de = {
   'settings.terminal.scheme': 'Textfarbe',
   'settings.send.title': 'Nachricht senden',
   'settings.send.newline': 'für neue Zeile',
+  'settings.tasks': 'Aufgaben',
+  'settings.tasks.view': 'Aufgaben-Stil',
+  'task.view.list': 'To-do-Liste',
+  'task.view.note': 'Notizzettel',
+  'task.view.list.sub': 'Kompakte Liste, einzeln abhaken',
+  'task.view.note.sub': 'Große Zettel – frei schreiben, alles senden',
+  'task.note_placeholder': 'Schreib etwas auf und sende alles an deinen Agenten…',
 
   // Theme Menu
   'theme.section.color': 'Farben',

--- a/src-ui/src/i18n/en.ts
+++ b/src-ui/src/i18n/en.ts
@@ -110,6 +110,14 @@ export const en = {
   'settings.gambit': 'Gambit',
   'settings.send.title': 'Send message',
   'settings.send.newline': 'for a new line',
+  // Task board form (to-do list vs sticky notes)
+  'settings.tasks': 'Tasks',
+  'settings.tasks.view': 'Task style',
+  'task.view.list': 'To-do List',
+  'task.view.note': 'Sticky Notes',
+  'task.view.list.sub': 'Compact checklist, tick off one by one',
+  'task.view.note.sub': 'Roomy notes — jot freely, send the whole thing',
+  'task.note_placeholder': 'Jot something down, send it all to your agent…',
 
   // Theme Menu
   'theme.section.color': 'Colors',

--- a/src-ui/src/i18n/es.ts
+++ b/src-ui/src/i18n/es.ts
@@ -103,6 +103,13 @@ export const es = {
   'settings.terminal.scheme': 'Color del texto',
   'settings.send.title': 'Enviar mensaje',
   'settings.send.newline': 'para nueva línea',
+  'settings.tasks': 'Tareas',
+  'settings.tasks.view': 'Estilo de tareas',
+  'task.view.list': 'Lista de tareas',
+  'task.view.note': 'Notas adhesivas',
+  'task.view.list.sub': 'Lista compacta, marca una a una',
+  'task.view.note.sub': 'Notas amplias: escribe y envía todo',
+  'task.note_placeholder': 'Anota algo y envíalo entero a tu agente…',
 
   // Theme Menu
   'theme.section.color': 'Colores',

--- a/src-ui/src/i18n/fr.ts
+++ b/src-ui/src/i18n/fr.ts
@@ -103,6 +103,13 @@ export const fr = {
   'settings.terminal.scheme': 'Couleur du texte',
   'settings.send.title': 'Envoyer le message',
   'settings.send.newline': 'pour un saut de ligne',
+  'settings.tasks': 'Tâches',
+  'settings.tasks.view': 'Style des tâches',
+  'task.view.list': 'Liste de tâches',
+  'task.view.note': 'Notes autocollantes',
+  'task.view.list.sub': 'Liste compacte, à cocher une par une',
+  'task.view.note.sub': 'Grandes notes : écrivez et envoyez tout',
+  'task.note_placeholder': 'Notez quelque chose et envoyez le tout à votre agent…',
 
   // Theme Menu
   'theme.section.color': 'Couleurs',

--- a/src-ui/src/i18n/ja.ts
+++ b/src-ui/src/i18n/ja.ts
@@ -103,6 +103,13 @@ export const ja = {
   'settings.terminal.scheme': '文字色',
   'settings.send.title': 'メッセージを送信',
   'settings.send.newline': '改行',
+  'settings.tasks': 'タスク',
+  'settings.tasks.view': 'タスクの表示',
+  'task.view.list': 'To-Do リスト',
+  'task.view.note': '付箋',
+  'task.view.list.sub': 'コンパクトな一覧、ひとつずつチェック',
+  'task.view.note.sub': '大きな付箋にまとめて書いて送信',
+  'task.note_placeholder': 'メモを書いて、まとめて送信…',
 
   // Theme Menu
   'theme.section.color': 'カラー',

--- a/src-ui/src/i18n/ko.ts
+++ b/src-ui/src/i18n/ko.ts
@@ -103,6 +103,13 @@ export const ko = {
   'settings.terminal.scheme': '글자 색',
   'settings.send.title': '메시지 전송',
   'settings.send.newline': '줄바꿈',
+  'settings.tasks': '작업',
+  'settings.tasks.view': '작업 표시 방식',
+  'task.view.list': '할 일 목록',
+  'task.view.note': '메모지',
+  'task.view.list.sub': '간결한 체크리스트, 하나씩 체크',
+  'task.view.note.sub': '큰 메모지에 자유롭게 적어 한 번에 전송',
+  'task.note_placeholder': '메모를 적어 에이전트로 한 번에 보내기…',
 
   // Theme Menu
   'theme.section.color': '색상',

--- a/src-ui/src/i18n/pt.ts
+++ b/src-ui/src/i18n/pt.ts
@@ -104,6 +104,13 @@ export const pt = {
   'settings.terminal.scheme': 'Cor do texto',
   'settings.send.title': 'Enviar mensagem',
   'settings.send.newline': 'para nova linha',
+  'settings.tasks': 'Tarefas',
+  'settings.tasks.view': 'Estilo de tarefas',
+  'task.view.list': 'Lista de tarefas',
+  'task.view.note': 'Notas adesivas',
+  'task.view.list.sub': 'Lista compacta, marque uma a uma',
+  'task.view.note.sub': 'Notas amplas: escreva e envie tudo',
+  'task.note_placeholder': 'Anote algo e envie tudo ao seu agente…',
 
   // Theme Menu
   'theme.section.color': 'Cores',

--- a/src-ui/src/i18n/ru.ts
+++ b/src-ui/src/i18n/ru.ts
@@ -104,6 +104,13 @@ export const ru = {
   'settings.terminal.scheme': 'Цвет текста',
   'settings.send.title': 'Отправить сообщение',
   'settings.send.newline': 'для новой строки',
+  'settings.tasks': 'Задачи',
+  'settings.tasks.view': 'Стиль задач',
+  'task.view.list': 'Список дел',
+  'task.view.note': 'Стикеры',
+  'task.view.list.sub': 'Компактный список, отмечайте по одному',
+  'task.view.note.sub': 'Большие стикеры — пишите и отправляйте целиком',
+  'task.note_placeholder': 'Запишите что-нибудь и отправьте целиком агенту…',
 
   // Theme Menu
   'theme.section.color': 'Цвета',

--- a/src-ui/src/i18n/vi.ts
+++ b/src-ui/src/i18n/vi.ts
@@ -106,6 +106,13 @@ export const vi = {
   'settings.terminal.scheme': 'Màu chữ',
   'settings.send.title': 'Gửi tin nhắn',
   'settings.send.newline': 'để xuống dòng',
+  'settings.tasks': 'Tác vụ',
+  'settings.tasks.view': 'Kiểu tác vụ',
+  'task.view.list': 'Danh sách việc cần làm',
+  'task.view.note': 'Ghi chú dán',
+  'task.view.list.sub': 'Danh sách gọn, tick từng mục',
+  'task.view.note.sub': 'Ghi chú lớn — viết thoải mái, gửi cả đoạn',
+  'task.note_placeholder': 'Ghi vài dòng rồi gửi cả đoạn cho agent…',
 
   // Theme Menu
   'theme.section.color': 'Màu sắc',

--- a/src-ui/src/i18n/zh-CN.ts
+++ b/src-ui/src/i18n/zh-CN.ts
@@ -108,6 +108,13 @@ export const zhCN = {
   'settings.gambit': '妙手',
   'settings.send.title': '发送消息',
   'settings.send.newline': '换行',
+  'settings.tasks': '任务',
+  'settings.tasks.view': '任务形态',
+  'task.view.list': '待办式',
+  'task.view.note': '便签式',
+  'task.view.list.sub': '紧凑清单，逐条勾选',
+  'task.view.note.sub': '大便签，随手写、整段发给 AI',
+  'task.note_placeholder': '写点什么，整段发给 AI…',
 
   // Theme Menu
   'theme.section.color': '配色',

--- a/src-ui/src/i18n/zh-TW.ts
+++ b/src-ui/src/i18n/zh-TW.ts
@@ -108,6 +108,13 @@ export const zhTW = {
   'settings.gambit': '妙手',
   'settings.send.title': '發送訊息',
   'settings.send.newline': '換行',
+  'settings.tasks': '任務',
+  'settings.tasks.view': '任務形態',
+  'task.view.list': '待辦式',
+  'task.view.note': '便籤式',
+  'task.view.list.sub': '緊湊清單，逐條勾選',
+  'task.view.note.sub': '大便籤，隨手寫、整段發給 AI',
+  'task.note_placeholder': '寫點什麼，整段發給 AI…',
 
   // Theme Menu
   'theme.section.color': '配色',

--- a/src-ui/src/lib/personalization.ts
+++ b/src-ui/src/lib/personalization.ts
@@ -40,6 +40,14 @@ export const THEME_SHAPES: { code: ThemeShape; label: string }[] = [
   { code: 'carbon', label: 'Carbon' },
 ];
 
+// ─── Task board form (to-do list vs sticky notes) ────────────────────────────
+// Two presentations of the same task data, chosen in the settings "Tasks"
+// section. Icons are inlined in SettingsModal (mirrors the other sections).
+export const TASK_VIEW_MODES: { code: 'list' | 'note'; labelKey: string; subKey: string }[] = [
+  { code: 'list', labelKey: 'task.view.list', subKey: 'task.view.list.sub' },
+  { code: 'note', labelKey: 'task.view.note', subKey: 'task.view.note.sub' },
+];
+
 // ─── File-tree icon art themes ───────────────────────────────────────────────
 export const ICON_ART_THEMES: { id: IconTheme; folderSrc: string }[] = [
   { id: 'outline',          folderSrc: '/icons/themes/outline/folder-closed.svg'          },

--- a/src-ui/src/store/app-state.tsx
+++ b/src-ui/src/store/app-state.tsx
@@ -139,6 +139,12 @@ export interface AppState {
   // 'columns' = 1×4 vertical strip. Only takes effect inside a tab
   // whose tool is 'multi-agent'; other tabs ignore it.
   multiAgentLayout: 'grid' | 'columns';
+
+  // Right-panel task board form. 'list' = compact to-do checklist (default),
+  // 'note' = big sticky-note cards (traffic-light status + timestamp + roomy
+  // text area). Same task data either way — purely a presentation choice made
+  // in the settings modal. Default 'list' so existing users see no change.
+  taskViewMode: 'list' | 'note';
 }
 
 // ─── Tab tool predicates ────────────────────────────────────────────────────
@@ -213,7 +219,8 @@ type Action =
   | { type: 'SET_FOCUSED_PANE'; tabId: string; paneIdx: number | null }
   | { type: 'TOGGLE_LEFT_PANEL' }
   | { type: 'TOGGLE_RIGHT_PANEL' }
-  | { type: 'SET_MULTI_AGENT_LAYOUT'; layout: 'grid' | 'columns' };
+  | { type: 'SET_MULTI_AGENT_LAYOUT'; layout: 'grid' | 'columns' }
+  | { type: 'SET_TASK_VIEW_MODE'; mode: 'list' | 'note' };
 
 // ─── Reducer ─────────────────────────────────────────────────────────────────
 
@@ -440,6 +447,10 @@ function reducer(state: AppState, action: Action): AppState {
       try { localStorage.setItem('cc-ma-layout', action.layout); } catch {}
       return { ...state, multiAgentLayout: action.layout };
     }
+    case 'SET_TASK_VIEW_MODE': {
+      try { localStorage.setItem('cc-task-view', action.mode); } catch {}
+      return { ...state, taskViewMode: action.mode };
+    }
     default:
       return state;
   }
@@ -549,11 +560,14 @@ function getInitialState(): AppState {
   let leftPanelHidden = false;
   let rightPanelHidden = false;
   let multiAgentLayout: 'grid' | 'columns' = 'grid';
+  let taskViewMode: 'list' | 'note' = 'list';
   try {
     leftPanelHidden = localStorage.getItem('cc-left-hidden') === '1';
     rightPanelHidden = localStorage.getItem('cc-right-hidden') === '1';
     const savedLayout = localStorage.getItem('cc-ma-layout');
     if (savedLayout === 'columns' || savedLayout === 'grid') multiAgentLayout = savedLayout;
+    const savedTaskView = localStorage.getItem('cc-task-view');
+    if (savedTaskView === 'list' || savedTaskView === 'note') taskViewMode = savedTaskView;
   } catch {}
 
   return {
@@ -574,6 +588,7 @@ function getInitialState(): AppState {
     leftPanelHidden,
     rightPanelHidden,
     multiAgentLayout,
+    taskViewMode,
   };
 }
 

--- a/src-ui/src/styles/global.css
+++ b/src-ui/src/styles/global.css
@@ -1505,9 +1505,9 @@ body.gambit-docked .chat-reader-container {
    Buttons / inputs / textareas / anchors aren't matched by the
    element list at all, so their own hover/focus bgs are
    untouched. */
-:is([data-shape="glass"], [data-shape="carbon"]) .panel-left :is(div, section, aside, nav, header, footer, main):not(.launchpad-card, .launchpad-card-group, .task-card, .task-droppable-area, .guide-card, .remote-form-card, .remote-form-overlay, .remote-protocol-toggle, .remote-pill, .chat-input-container, .library-item, .library-tabs, .ctx-menu, .gambit, .tool-config-modal, .tab-status-dot, .heatmap-cell, .diff-line),
-:is([data-shape="glass"], [data-shape="carbon"]) .panel-right :is(div, section, aside, nav, header, footer, main):not(.launchpad-card, .launchpad-card-group, .task-card, .task-droppable-area, .guide-card, .remote-form-card, .remote-form-overlay, .remote-protocol-toggle, .remote-pill, .chat-input-container, .library-item, .library-tabs, .ctx-menu, .gambit, .tool-config-modal, .tab-status-dot, .heatmap-cell, .diff-line),
-:is([data-shape="glass"], [data-shape="carbon"]) .panel-center :is(div, section, aside, nav, header, footer, main):not(.launchpad-card, .launchpad-card-group, .task-card, .task-droppable-area, .guide-card, .remote-form-card, .remote-form-overlay, .remote-protocol-toggle, .remote-pill, .chat-input-container, .library-item, .library-tabs, .ctx-menu, .gambit, .tool-config-modal, .tab-status-dot, .heatmap-cell, .diff-line) {
+:is([data-shape="glass"], [data-shape="carbon"]) .panel-left :is(div, section, aside, nav, header, footer, main):not(.launchpad-card, .launchpad-card-group, .task-card, .task-note-card, .task-droppable-area, .guide-card, .remote-form-card, .remote-form-overlay, .remote-protocol-toggle, .remote-pill, .chat-input-container, .library-item, .library-tabs, .ctx-menu, .gambit, .tool-config-modal, .tab-status-dot, .heatmap-cell, .diff-line),
+:is([data-shape="glass"], [data-shape="carbon"]) .panel-right :is(div, section, aside, nav, header, footer, main):not(.launchpad-card, .launchpad-card-group, .task-card, .task-note-card, .task-droppable-area, .guide-card, .remote-form-card, .remote-form-overlay, .remote-protocol-toggle, .remote-pill, .chat-input-container, .library-item, .library-tabs, .ctx-menu, .gambit, .tool-config-modal, .tab-status-dot, .heatmap-cell, .diff-line),
+:is([data-shape="glass"], [data-shape="carbon"]) .panel-center :is(div, section, aside, nav, header, footer, main):not(.launchpad-card, .launchpad-card-group, .task-card, .task-note-card, .task-droppable-area, .guide-card, .remote-form-card, .remote-form-overlay, .remote-protocol-toggle, .remote-pill, .chat-input-container, .library-item, .library-tabs, .ctx-menu, .gambit, .tool-config-modal, .tab-status-dot, .heatmap-cell, .diff-line) {
     background: transparent !important;
     border-color: transparent !important;
     box-shadow: none !important;
@@ -1549,6 +1549,7 @@ body.gambit-docked .chat-reader-container {
 }
 
 [data-shape="glass"] .task-card,
+[data-shape="glass"] .task-note-card,
 [data-shape="glass"] .guide-card,
 [data-shape="glass"] .chat-input-container,
 [data-shape="glass"] .library-item {


### PR DESCRIPTION
## What

Adds a **便签式 (sticky-note)** alternative to the right-panel task board, selectable in **Settings → 任务**. It's a second *view* of the same task data — switch anytime, every task is preserved.

Each note card: 3 traffic-light status dots (🔴进行中 / 🟡待办 / 🟢已完成, click to set), a created-at timestamp, a big auto-growing text body (escapes the cramped inline input), 删除 + 发送(▶) actions, and up/down drag reordering (dropping onto another group re-files the note's status). Default stays **待办式** so existing users are unaffected.

## Notes
- New: `TaskNoteView`, `TaskEmptyState` (shared greeting), `task-types` (shared model). `TaskBoard` owns state and swaps views — **list-mode drag untouched**.
- `taskViewMode` added to app-state (persists to `cc-task-view`); 7 i18n keys × 11 locales.
- `.task-note-card` added to the glass/carbon transparency whitelist (visible under the default carbon shape).
- Note body edits `title`; the list-only `description` is preserved but hidden in note mode (still sent to the agent).

## Test plan
- [ ] Settings → 任务 → toggle 待办式 / 便签式; choice persists across restart
- [ ] Create / edit / delete notes; set status via dots → card auto-sorts (红上→黄中→绿下)
- [ ] Drag to reorder within a group; drag across groups re-files status
- [ ] ▶ sends the note to the active terminal; disabled when empty / no active tab
- [ ] Switch modes — tasks carry over both ways
- [ ] Carbon (default) + Glass shapes both render the cards