### PR TITLE
feat(gambit): global open/close hotkey for the compose window

### DIFF
--- a/src-ui/src/components/center/ActiveGambit.tsx
+++ b/src-ui/src/components/center/ActiveGambit.tsx
@@ -19,8 +19,8 @@
 // switching tabs swaps what's shown inside the (still-open) panel so
 // text can't be misdirected to the wrong terminal.
 
-import { useCallback, useMemo } from 'react';
-import { useAppState, isSplitTool, paneSessionId } from '../../store/app-state';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useAppState, isSplitTool, paneSessionId, matchesGambitHotkey } from '../../store/app-state';
 import { getTabActions } from '../../lib/tab-actions';
 import { getFocusedPane } from '../../lib/pane-focus';
 import { Gambit } from './Gambit';
@@ -92,6 +92,32 @@ export function ActiveGambit() {
     if (!actions) return false;
     return actions.paste(text);
   }, [activeId, activeSession?.tool]);
+
+  // Global open/close hotkey (settings → 妙手). Registered in the CAPTURE
+  // phase on document so it fires BEFORE the focused xterm's own keydown —
+  // preventDefault then stops the combo (e.g. Ctrl+~) from leaking a control
+  // byte into the terminal. NOT gated on gambitOpen: ActiveGambit stays
+  // mounted app-wide even while the panel is closed, so the same key both
+  // opens and closes. Auto-repeat events are still suppressed (preventDefault)
+  // but don't re-toggle, so holding the key neither flickers nor leaks a byte.
+  const hotkey = state.gambitHotkey;
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      // IME composition in progress — let the IME keep the key (same guard
+      // every other keydown handler in this app uses, e.g. Gambit.tsx).
+      if (e.isComposing) return;
+      if (!matchesGambitHotkey(e, hotkey)) return;
+      // Suppress the combo for EVERY matching event — including auto-repeat —
+      // so a held key never leaks a byte into the xterm during the ~1 frame
+      // before Gambit grabs focus. Only the initial (non-repeat) press toggles.
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.repeat) return;
+      dispatch({ type: 'TOGGLE_GAMBIT' });
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [hotkey, dispatch]);
 
   if (!gambitOpen || !activeId) return null;
 

--- a/src-ui/src/components/common/SettingsModal.css
+++ b/src-ui/src/components/common/SettingsModal.css
@@ -277,6 +277,16 @@
 
 /* ── Keyboard: send-key cards ──────────────────────────────────────────── */
 .settings-key-row { display: flex; gap: 10px; flex-wrap: wrap; }
+/* Hotkey picker (妙手 toggle): 4 equal presets as an auto-fit grid so they
+   fill evenly (4-up when wide, fewer when narrow) instead of wrapping to a
+   ragged 3+1 the way a plain flex row does. min-width:0 lets the cards shrink
+   to the column — the shared .settings-key-card keeps min-width:160px for the
+   2-up send row above. */
+.settings-key-row--keys {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+.settings-key-row--keys .settings-key-card { min-width: 0; }
 .settings-key-card {
   display: flex;
   flex-direction: column;

--- a/src-ui/src/components/common/SettingsModal.tsx
+++ b/src-ui/src/components/common/SettingsModal.tsx
@@ -13,7 +13,7 @@
 // is unchanged; only the presentation moved.
 
 import { useEffect, useState, type ReactNode } from 'react';
-import { useAppState, useAppDispatch, type ThemeColor, type ThemeShape, type IconTheme } from '../../store/app-state';
+import { useAppState, useAppDispatch, GAMBIT_HOTKEYS, type GambitHotkey, type ThemeColor, type ThemeShape, type IconTheme } from '../../store/app-state';
 import { useT } from '../../i18n/useT';
 import { IS_MACOS } from '../../lib/platform';
 import { TERM_COLOR_SCHEMES } from '../center/TierTerminal';
@@ -165,6 +165,10 @@ export function SettingsModal() {
   const setEnterToSend = (value: boolean) => {
     dispatch({ type: 'SET_GAMBIT_ENTER_TO_SEND', value });
     try { localStorage.setItem('cc-gambit-enter-send', String(value)); } catch {}
+  };
+  const setGambitHotkey = (value: GambitHotkey) => {
+    dispatch({ type: 'SET_GAMBIT_HOTKEY', value });
+    try { localStorage.setItem('cc-gambit-hotkey', value); } catch {}
   };
 
   const hasBg = state.bgType !== 'none' && state.bgPath !== '';
@@ -361,6 +365,23 @@ export function SettingsModal() {
                     <span className="settings-key-combo"><kbd>{modKey}</kbd><span className="settings-key-plus">+</span><kbd>Enter</kbd></span>
                     <span className="settings-key-sub">Enter {t('settings.send.newline' as any)}</span>
                   </button>
+                </div>
+
+                <div className="settings-section-label">{t('settings.gambit.hotkey' as any)}</div>
+                <div className="settings-key-row settings-key-row--keys">
+                  {GAMBIT_HOTKEYS.map(h => {
+                    const active = state.gambitHotkey === h.code;
+                    return (
+                      <button
+                        key={h.code}
+                        className={`settings-key-card${active ? ' active' : ''}`}
+                        onClick={() => setGambitHotkey(h.code)}
+                        aria-pressed={active}
+                      >
+                        <span className="settings-key-combo"><kbd>{h.mod}</kbd><span className="settings-key-plus">+</span><kbd>{h.key}</kbd></span>
+                      </button>
+                    );
+                  })}
                 </div>
               </>
             )}

--- a/src-ui/src/i18n/de.ts
+++ b/src-ui/src/i18n/de.ts
@@ -104,6 +104,7 @@ export const de = {
   'settings.terminal.scheme': 'Textfarbe',
   'settings.send.title': 'Nachricht senden',
   'settings.send.newline': 'für neue Zeile',
+  'settings.gambit.hotkey': 'Kürzel zum Umschalten',
   'settings.tasks': 'Aufgaben',
   'settings.tasks.view': 'Aufgaben-Stil',
   'task.view.list': 'To-do-Liste',

--- a/src-ui/src/i18n/en.ts
+++ b/src-ui/src/i18n/en.ts
@@ -110,6 +110,7 @@ export const en = {
   'settings.gambit': 'Gambit',
   'settings.send.title': 'Send message',
   'settings.send.newline': 'for a new line',
+  'settings.gambit.hotkey': 'Toggle shortcut',
   // Task board form (to-do list vs sticky notes)
   'settings.tasks': 'Tasks',
   'settings.tasks.view': 'Task style',

--- a/src-ui/src/i18n/es.ts
+++ b/src-ui/src/i18n/es.ts
@@ -103,6 +103,7 @@ export const es = {
   'settings.terminal.scheme': 'Color del texto',
   'settings.send.title': 'Enviar mensaje',
   'settings.send.newline': 'para nueva línea',
+  'settings.gambit.hotkey': 'Atajo de teclado',
   'settings.tasks': 'Tareas',
   'settings.tasks.view': 'Estilo de tareas',
   'task.view.list': 'Lista de tareas',

--- a/src-ui/src/i18n/fr.ts
+++ b/src-ui/src/i18n/fr.ts
@@ -103,6 +103,7 @@ export const fr = {
   'settings.terminal.scheme': 'Couleur du texte',
   'settings.send.title': 'Envoyer le message',
   'settings.send.newline': 'pour un saut de ligne',
+  'settings.gambit.hotkey': 'Raccourci clavier',
   'settings.tasks': 'Tâches',
   'settings.tasks.view': 'Style des tâches',
   'task.view.list': 'Liste de tâches',

--- a/src-ui/src/i18n/ja.ts
+++ b/src-ui/src/i18n/ja.ts
@@ -103,6 +103,7 @@ export const ja = {
   'settings.terminal.scheme': '文字色',
   'settings.send.title': 'メッセージを送信',
   'settings.send.newline': '改行',
+  'settings.gambit.hotkey': '開閉ショートカット',
   'settings.tasks': 'タスク',
   'settings.tasks.view': 'タスクの表示',
   'task.view.list': 'To-Do リスト',

--- a/src-ui/src/i18n/ko.ts
+++ b/src-ui/src/i18n/ko.ts
@@ -103,6 +103,7 @@ export const ko = {
   'settings.terminal.scheme': '글자 색',
   'settings.send.title': '메시지 전송',
   'settings.send.newline': '줄바꿈',
+  'settings.gambit.hotkey': '열기/닫기 단축키',
   'settings.tasks': '작업',
   'settings.tasks.view': '작업 표시 방식',
   'task.view.list': '할 일 목록',

--- a/src-ui/src/i18n/pt.ts
+++ b/src-ui/src/i18n/pt.ts
@@ -104,6 +104,7 @@ export const pt = {
   'settings.terminal.scheme': 'Cor do texto',
   'settings.send.title': 'Enviar mensagem',
   'settings.send.newline': 'para nova linha',
+  'settings.gambit.hotkey': 'Atalho de teclado',
   'settings.tasks': 'Tarefas',
   'settings.tasks.view': 'Estilo de tarefas',
   'task.view.list': 'Lista de tarefas',

--- a/src-ui/src/i18n/ru.ts
+++ b/src-ui/src/i18n/ru.ts
@@ -104,6 +104,7 @@ export const ru = {
   'settings.terminal.scheme': 'Цвет текста',
   'settings.send.title': 'Отправить сообщение',
   'settings.send.newline': 'для новой строки',
+  'settings.gambit.hotkey': 'Горячая клавиша',
   'settings.tasks': 'Задачи',
   'settings.tasks.view': 'Стиль задач',
   'task.view.list': 'Список дел',

--- a/src-ui/src/i18n/vi.ts
+++ b/src-ui/src/i18n/vi.ts
@@ -106,6 +106,7 @@ export const vi = {
   'settings.terminal.scheme': 'Màu chữ',
   'settings.send.title': 'Gửi tin nhắn',
   'settings.send.newline': 'để xuống dòng',
+  'settings.gambit.hotkey': 'Phím tắt bật/tắt',
   'settings.tasks': 'Tác vụ',
   'settings.tasks.view': 'Kiểu tác vụ',
   'task.view.list': 'Danh sách việc cần làm',

--- a/src-ui/src/i18n/zh-CN.ts
+++ b/src-ui/src/i18n/zh-CN.ts
@@ -108,6 +108,7 @@ export const zhCN = {
   'settings.gambit': '妙手',
   'settings.send.title': '发送消息',
   'settings.send.newline': '换行',
+  'settings.gambit.hotkey': '开关快捷键',
   'settings.tasks': '任务',
   'settings.tasks.view': '任务形态',
   'task.view.list': '待办式',

--- a/src-ui/src/i18n/zh-TW.ts
+++ b/src-ui/src/i18n/zh-TW.ts
@@ -108,6 +108,7 @@ export const zhTW = {
   'settings.gambit': '妙手',
   'settings.send.title': '發送訊息',
   'settings.send.newline': '換行',
+  'settings.gambit.hotkey': '開關快捷鍵',
   'settings.tasks': '任務',
   'settings.tasks.view': '任務形態',
   'task.view.list': '待辦式',

--- a/src-ui/src/store/app-state.tsx
+++ b/src-ui/src/store/app-state.tsx
@@ -37,6 +37,38 @@ export type IconTheme =
   | 'outline' | 'material' | 'vscode-icons' | 'catppuccin-mocha'
   | 'devicon' | 'fluent' | 'symbols' | 'coffee';
 
+// Gambit (妙手) open/close hotkey presets, each a single-modifier combo.
+// Default `ctrl-backquote` borrows VS Code's "toggle terminal panel" muscle
+// memory and is the safest pick: no CJK IME claim, no macOS dead-key/typed-
+// glyph side effect, and the host terminal rarely needs a bare Ctrl+`. The
+// `alt-*` entries are opt-in alternatives — a hosted CLI (Claude/Codex) may
+// itself bind Alt chords inside the PTY, so when the user picks one the global
+// listener will intercept it app-wide (acceptable because they chose it). We
+// show literal `Ctrl`/`Alt` (not ⌃/⌥) for the mass-market audience, and match
+// on `e.code` (physical key) because Alt on macOS rewrites `e.key` into the
+// typed glyph (å/œ) — only the code is stable.
+export const GAMBIT_HOTKEYS = [
+  { code: 'ctrl-backquote', mod: 'Ctrl', key: '~', eventCode: 'Backquote', modifier: 'ctrl' },
+  { code: 'alt-backquote',  mod: 'Alt',  key: '~', eventCode: 'Backquote', modifier: 'alt' },
+  { code: 'alt-a',          mod: 'Alt',  key: 'A', eventCode: 'KeyA',      modifier: 'alt' },
+  { code: 'alt-q',          mod: 'Alt',  key: 'Q', eventCode: 'KeyQ',      modifier: 'alt' },
+] as const;
+
+export type GambitHotkey = typeof GAMBIT_HOTKEYS[number]['code'];
+
+// True when a keydown matches the configured hotkey. The caller MUST then call
+// BOTH preventDefault (cancels the byte/glyph — this is what stops Alt+A from
+// typing `å` on macOS) AND stopPropagation (keeps the combo from reaching
+// xterm's own keydown). metaKey is always rejected: on macOS Cmd+` is the
+// system "cycle windows" shortcut, so the Ctrl preset stays Control everywhere.
+export function matchesGambitHotkey(e: KeyboardEvent, hotkey: GambitHotkey): boolean {
+  const def = GAMBIT_HOTKEYS.find(h => h.code === hotkey) ?? GAMBIT_HOTKEYS[0];
+  if (e.metaKey || e.code !== def.eventCode) return false;
+  return def.modifier === 'ctrl'
+    ? e.ctrlKey && !e.altKey
+    : e.altKey && !e.ctrlKey;
+}
+
 /// One pane inside a multi-agent Tab. `paneIdx` is 1-indexed (1..4)
 /// matching the user-visible badge and the MCP session id suffix —
 /// sessionId = `${tabId}::pane-${paneIdx}`. The Rust MCP server's
@@ -130,6 +162,10 @@ export interface AppState {
   // settings modal because the muscle-memory split is per-user / per-OS.
   gambitEnterToSend: boolean;
 
+  // Gambit open/close hotkey preset (settings → 妙手). One of GAMBIT_HOTKEYS;
+  // a global capture-phase listener in ActiveGambit toggles on a match.
+  gambitHotkey: GambitHotkey;
+
   // IDE-style layout toggles driven from titlebar controls.
   // Default both panels visible — matches first-time user expectation.
   leftPanelHidden: boolean;
@@ -212,6 +248,7 @@ type Action =
   | { type: 'TOGGLE_SETTINGS' }
   | { type: 'SET_SETTINGS_OPEN'; open: boolean }
   | { type: 'SET_GAMBIT_ENTER_TO_SEND'; value: boolean }
+  | { type: 'SET_GAMBIT_HOTKEY'; value: GambitHotkey }
   | { type: 'SET_GAMBIT_DRAFT'; id: string; draft: string }
   | { type: 'SET_PANE_TOOL'; tabId: string; paneIdx: number; tool: ToolType; toolData?: string; folderPath?: string | null }
   | { type: 'SET_PANE_SENTINEL'; tabId: string; paneIdx: number; enabled: boolean }
@@ -357,6 +394,8 @@ function reducer(state: AppState, action: Action): AppState {
       return { ...state, settingsOpen: action.open };
     case 'SET_GAMBIT_ENTER_TO_SEND':
       return { ...state, gambitEnterToSend: action.value };
+    case 'SET_GAMBIT_HOTKEY':
+      return { ...state, gambitHotkey: action.value };
     case 'SET_GAMBIT_DRAFT':
       return {
         ...state,
@@ -511,6 +550,9 @@ function getInitialState(): AppState {
   let wallpaperOpacity = 70;
   // Default Enter-to-send; only opt-out if the user explicitly stored 'false'.
   let gambitEnterToSend = true;
+  // Default Gambit hotkey = Ctrl+~ (VS Code terminal-toggle muscle memory,
+  // no macOS dead-key clash). Overridden only by a stored valid preset.
+  let gambitHotkey: GambitHotkey = 'ctrl-backquote';
   try {
     const storedPath = localStorage.getItem('cc-bg-path');
     const storedType = localStorage.getItem('cc-bg-type') as 'image' | 'video' | 'none' | null;
@@ -534,6 +576,10 @@ function getInitialState(): AppState {
     termColorScheme = localStorage.getItem('cc-term-scheme') || '';
     termFont = localStorage.getItem('cc-term-font') || '';
     gambitEnterToSend = localStorage.getItem('cc-gambit-enter-send') !== 'false';
+    const storedHotkey = localStorage.getItem('cc-gambit-hotkey');
+    if (storedHotkey && GAMBIT_HOTKEYS.some(h => h.code === storedHotkey)) {
+      gambitHotkey = storedHotkey as GambitHotkey;
+    }
     // New key (post-refactor): wallpaper opacity, 0-100, larger = more
     // visible. Old key was `cc-wallpaper-dim` (0-80, larger = darker
     // overlay). On first load after upgrade, fall back to the legacy
@@ -585,6 +631,7 @@ function getInitialState(): AppState {
     gambitOpen: false,
     settingsOpen: false,
     gambitEnterToSend,
+    gambitHotkey,
     leftPanelHidden,
     rightPanelHidden,
     multiAgentLayout,


### PR DESCRIPTION
## 概要
给「妙手」(Gambit) 撰写窗加了一个**全局开关快捷键**,默认 `Ctrl+~`(对齐 VS Code 开关终端的肌肉记忆),可在 **设置 → 妙手** 里切换 `Ctrl+~` / `Alt+~` / `Alt+A` / `Alt+Q`,选择持久化到 localStorage。

## 改动
- **监听**:`ActiveGambit` 里 document **capture 阶段** keydown,先于 xterm 抢键;`preventDefault`+`stopPropagation` 防止按键漏成控制字节进终端。用 `e.code` 物理键判定(Mac 上 Alt 会把 `e.key` 变 å/œ),排除 `metaKey`,守 `isComposing`,`repeat` 先拦截再跳过 toggle。
- **设置**:4 张键位卡片(auto-fit grid 均匀排布,不再 3+1);state/reducer/持久化沿用 `gambitEnterToSend` 同款。
- **i18n**:`settings.gambit.hotkey` 补齐全部 11 个语言文件。
- 不动左侧 Explorer 的妙手按钮,**不加任何悬停 tooltip**。

## Review
本分支已过一轮 code-review(3 路独立 finder + 复核),修掉 1 个真 bug(`e.repeat` 在 `preventDefault` 前 return → 按住键漏字节进终端)+ 补 `isComposing` guard + 注释纠偏 + 布局均匀化。

## Test plan
- [x] `tsc --noEmit` 通过
- [ ] dev 实测:`Ctrl+~` 开/关妙手、焦点自动进输入框、设置切 4 种键位、终端不漏字符、CJK 输入法组合中不误触发
