### PR TITLE
Release 2.9.7 — titlebar tabs · Linux IME fix · resume dir · feedback · perf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,39 +77,12 @@ jobs:
           cd src-ui
           npm ci
 
-      # ── Linux-only stopgap: ship xterm 6.1.0-beta on Linux ──────────────
-      # The committed deps stay on stable 6.0.0 (Windows/macOS ship that).
-      # Only the Linux release artifact pulls the 6.1.0-beta line, which
-      # carries upstream's reworked IME composition handling and clears the
-      # WebKit2GTK CJK-punctuation duplication on the raw terminal
-      # (issue #37 / xtermjs#5374 — open, no stable fix yet). Windows is
-      # Chromium and never had the bug; macOS stays on stable too.
-      # `--no-save` keeps package.json / package-lock.json untouched.
-      # REMOVE this whole block once xterm 6.1.0 ships stable and the
-      # committed deps are bumped for every platform.
-      - name: "[Linux] Override xterm with 6.1.0-beta (IME stopgap)"
-        if: startsWith(matrix.platform, 'ubuntu-')
-        run: |
-          cd src-ui
-          npm install --no-save \
-            @xterm/xterm@6.1.0-beta.287 \
-            @xterm/addon-fit@0.12.0-beta.287 \
-            @xterm/addon-web-links@0.13.0-beta.287 \
-            @xterm/addon-webgl@0.20.0-beta.286
-
-      # Linux builds skip `tsc` because 6.1.0-beta dropped the `customGlyphs`
-      # init option from its types (it is now always-on); the option is still
-      # valid on the committed 6.0.0 and is harmlessly ignored at runtime on
-      # beta. `vite build` transpiles without type-checking, and Windows/macOS
-      # still run the full `tsc` gate, so no type coverage is lost overall.
-      - name: Build frontend (Linux — vite only)
-        if: startsWith(matrix.platform, 'ubuntu-')
-        run: |
-          cd src-ui
-          npx vite build
-
-      - name: Build frontend (Windows / macOS — tsc + vite)
-        if: ${{ !startsWith(matrix.platform, 'ubuntu-') }}
+      # All platforms build identically on stable xterm 6.0.0. The Linux CJK
+      # IME punctuation-duplication bug (issue #37 / xtermjs#5374) is fixed in
+      # the app layer instead — see TierTerminal.tsx (__IS_LINUX__-gated
+      # suppression of xterm's composition events) — so there is no longer a
+      # Linux-only dependency override or a Linux-only tsc-skip build path.
+      - name: Build frontend (tsc + vite)
         run: |
           cd src-ui
           npm run build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "coffee-cli"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coffee-cli"
-version = "2.9.6"
+version = "2.9.7"
 edition = "2021"
 description = "Lightweight Multi-layer AI CLI Terminal"
 license = "AGPL-3.0-or-later"

--- a/install/release-notes-template.md
+++ b/install/release-notes-template.md
@@ -1,39 +1,54 @@
 <details open>
 <summary><b>🇨🇳 简体中文</b></summary>
 
-- 妙手悬浮输入框新增全局开关快捷键:一键唤出 / 收起,默认 `Ctrl+~`(沿用 VS Code 终端开关的手感),也能在 设置 → 妙手 里换成 `Alt+~` / `Alt+A` / `Alt+Q`。
-- 修复妙手输入长文时的滚动：文字超出输入框后，视图会自动跟随光标，不再每打一个字就跳回顶部。
+- 工具标签页移到了标题栏那一行——像 Chrome 和系统终端一样长在拖动条上，不再单独占一行，切换更顺手，也省出更多纵向空间。
+- 修复 Linux 下用中文输入法打标点（，。？）时字符不断重复累积的问题。
+- 点击历史会话的「继续本轮对话」，现在会正确回到该会话所在的项目目录。
+- 设置里新增「BUG / 建议」反馈入口，一键跳转提交问题（国内访问走 GitCode）。
+- 多标签页长时间使用更稳：限制 GPU 上下文数量、后台标签页自动降频，减少卡顿。
 
 </details>
 
 <details>
 <summary><b>🇹🇼 繁體中文</b></summary>
 
-- 妙手懸浮輸入框新增全域開關快捷鍵：一鍵喚出 / 收起，預設 `Ctrl+~`（沿用 VS Code 終端開關的手感），也能在 設定 → 妙手 裡換成 `Alt+~` / `Alt+A` / `Alt+Q`。
-- 修復妙手輸入長文時的捲動：文字超出輸入框後，視圖會自動跟隨游標，不再每打一個字就跳回頂部。
+- 工具分頁移到了標題列那一行——像 Chrome 和系統終端機一樣長在拖曳列上，不再單獨佔一行，切換更順手，也省出更多縱向空間。
+- 修復 Linux 下用中文輸入法打標點（，。？）時字元不斷重複累積的問題。
+- 點擊歷史對話的「繼續本輪對話」，現在會正確回到該對話所在的專案目錄。
+- 設定裡新增「BUG / 建議」回饋入口，一鍵跳轉提交問題。
+- 多分頁長時間使用更穩：限制 GPU 上下文數量、背景分頁自動降頻，減少卡頓。
 
 </details>
 
 <details>
 <summary><b>🇬🇧 English</b></summary>
 
-- The Gambit compose window now has a global toggle hotkey — summon or dismiss it with a single key. Defaults to `Ctrl+~` (VS Code terminal-toggle muscle memory); switch it to `Alt+~` / `Alt+A` / `Alt+Q` under Settings → Gambit.
-- Fixed scrolling in the Gambit compose box: once your text runs past the visible area, the view now follows your caret instead of snapping back to the top on every keystroke.
+- Tool tabs moved onto the titlebar — they now sit on the drag bar like Chrome and the OS terminals instead of taking their own row. Switching feels more natural and you get more vertical space.
+- Fixed CJK punctuation (，。？) duplicating and piling up when typed via an IME on Linux.
+- Clicking "Continue this session" on a history entry now returns to that session's actual project folder.
+- Added a "BUG / Suggestion" feedback entry in Settings — one click to file an issue.
+- Steadier over long multi-tab sessions: we cap GPU contexts and throttle backgrounded tabs to cut stutter.
 
 </details>
 
 <details>
 <summary><b>🇯🇵 日本語</b></summary>
 
-- 一手のフローティング入力ウィンドウにグローバルの開閉ホットキーを追加 — ワンキーで呼び出し / 収納できます。既定は `Ctrl+~`（VS Code のターミナル開閉と同じ操作感）。設定 → 一手 で `Alt+~` / `Alt+A` / `Alt+Q` に変更できます。
-- 一手の入力欄のスクロールを修正：文字が表示領域を超えても、ビューがカーソルに追従するようになり、1 文字打つたびに先頭へ戻ることがなくなりました。
+- ツールのタブをタイトルバーに移動 — Chrome や OS のターミナルと同じくドラッグバー上に並ぶようになり、独立した行を取らなくなりました。切り替えがより自然になり、縦のスペースも広がります。
+- Linux で IME を使って句読点（，。？）を入力すると文字が重複して増え続ける問題を修正しました。
+- 履歴の「このセッションを続ける」をクリックした際、そのセッションの実際のプロジェクトフォルダーに正しく戻るようになりました。
+- 設定に「BUG / 提案」フィードバック入口を追加 — ワンクリックで課題を報告できます。
+- 複数タブでの長時間利用がより安定：GPU コンテキスト数を制限し、バックグラウンドのタブを間引いてカクつきを軽減します。
 
 </details>
 
 <details>
 <summary><b>🇰🇷 한국어</b></summary>
 
-- 한 수 플로팅 입력 창에 전역 토글 단축키 추가 — 키 하나로 불러오거나 닫을 수 있어요. 기본값은 `Ctrl+~` (VS Code 터미널 토글과 같은 감각). 설정 → 한 수 에서 `Alt+~` / `Alt+A` / `Alt+Q` 로 바꿀 수 있습니다.
-- 한 수 입력창 스크롤 수정: 글이 보이는 영역을 넘어가도 화면이 커서를 따라가며, 한 글자 칠 때마다 맨 위로 튕기지 않습니다.
+- 도구 탭이 타이틀바로 이동 — Chrome나 OS 터미널처럼 드래그 바 위에 자리하며, 더 이상 별도의 줄을 차지하지 않습니다. 전환이 더 자연스럽고 세로 공간도 넓어집니다.
+- Linux에서 IME로 문장부호（，。？）를 입력할 때 문자가 중복되어 계속 쌓이는 문제를 수정했습니다.
+- 기록에서 "이 세션 계속하기"를 클릭하면 이제 해당 세션의 실제 프로젝트 폴더로 올바르게 돌아갑니다.
+- 설정에 "BUG / 제안" 피드백 입구를 추가 — 한 번의 클릭으로 이슈를 남길 수 있습니다.
+- 여러 탭을 오래 사용해도 더 안정적: GPU 컨텍스트 수를 제한하고 백그라운드 탭을 스로틀링하여 버벅임을 줄였습니다.
 
 </details>

--- a/src-ui/src/components/center/CenterPanel.css
+++ b/src-ui/src/components/center/CenterPanel.css
@@ -9,14 +9,19 @@
   border-radius: 0; /* Fully flush, edge to edge */
 }
 
+/* Tool-tab strip. Portaled into the titlebar (#titlebar-tab-slot) so the tabs
+   sit on the drag bar like Windows Terminal / Chrome instead of a separate row
+   inside the content. Fills the bar height; tabs are vertically-centered pills. */
 .chrome-tabs-header {
   display: flex;
-  align-items: flex-end;
-  padding: 8px 12px 0 12px;
+  align-items: stretch;
+  height: 100%;
+  padding: 0 2px 0 8px;
   border-bottom: none;
   position: relative;
   z-index: 10;
   gap: 2px;
+  min-width: 0;
 }
 
 .chrome-tab {
@@ -24,17 +29,23 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  height: 38px;
-  padding: 0 16px;
+  height: 100%;
+  padding: 0 12px;
   font-size: 13px;
   font-weight: 500;
   color: var(--text-2);
   background: transparent;
+  /* --shape-radius-tab is ALREADY a top-only radius (e.g. `10px 10px 0 0`, or 0
+     in sharp/slab) — so the tab is rounded on top, square at the bottom. It
+     fills the bar to its bottom edge, and the active tab's fill meets the
+     content directly below (Windows-Terminal seam). Do NOT re-wrap this in
+     `var() var() 0 0` — that expands to 10 values and the browser drops it. */
   border-radius: var(--shape-radius-tab);
   cursor: pointer;
   user-select: none;
   flex: 0 1 auto;
-  max-width: 220px;
+  max-width: 200px;
+  min-width: 0;
   /* `transform` is part of the transition so siblings ease into their
    * shifted positions when another tab is being dragged past them
    * (browser-style slide-aside). The dragged tab itself overrides
@@ -75,26 +86,10 @@
   transition: none;
 }
 
-/* Chrome 'flare' pseudo-elements bridging the tab to the terminal background */
-.chrome-tab.active::before,
-.chrome-tab.active::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  width: 12px;
-  height: 12px;
-  pointer-events: none;
-}
-
-.chrome-tab.active::before {
-  left: -12px;
-  background: radial-gradient(circle at top left, transparent 12px, var(--bg-terminal) 12.5px);
-}
-
-.chrome-tab.active::after {
-  right: -12px;
-  background: radial-gradient(circle at top right, transparent 12px, var(--bg-terminal) 12.5px);
-}
+/* The Chrome "flare" pseudo-elements that seamed the active tab into the
+   terminal directly below it were removed when the strip moved up into the
+   titlebar — there's no adjacent terminal to bridge into up here. The active
+   tab now reads via its --bg-terminal fill alone (WT-style flat tab). */
 
 .chrome-tab-new {
   width: 28px;
@@ -107,8 +102,9 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  margin-left: 6px;
-  margin-bottom: 5px;
+  margin-left: 4px;
+  align-self: center;
+  flex-shrink: 0;
   transition: background 0.15s, color 0.15s;
 }
 

--- a/src-ui/src/components/center/CenterPanel.tsx
+++ b/src-ui/src/components/center/CenterPanel.tsx
@@ -851,6 +851,15 @@ export function CenterPanel() {
   // to count as an activation if the tab moved).
   const tabDragSuppressClickRef = useRef(false);
 
+  // The chrome tab strip renders into the titlebar (Windows-Terminal style),
+  // not a separate row inside the content — the tabs sit on the drag bar like
+  // Chrome / the OS terminals. We keep ALL the tab logic/state here (the tabs
+  // ARE the center's terminals) and just portal the rendered strip up into
+  // TitleBar's #titlebar-tab-slot. Slot resolves after first mount; the strip
+  // renders one frame later, which is imperceptible.
+  const [tabSlot, setTabSlot] = useState<HTMLElement | null>(null);
+  useEffect(() => { setTabSlot(document.getElementById('titlebar-tab-slot')); }, []);
+
   const onTabPointerDown = (e: React.PointerEvent<HTMLDivElement>, sessionId: string) => {
     // Ignore non-primary buttons + clicks on close button / status indicator
     if (e.button !== 0) return;
@@ -1177,6 +1186,7 @@ export function CenterPanel() {
         </div>,
         document.body
       )}
+      {tabSlot && createPortal(
       <div ref={tabsHeaderRef} className="chrome-tabs-header" data-count={terminals.filter(s => !s.isHidden || s.id === activeTerminalId).length}>
         {(() => {
           // Pre-compute visible-strip index for each session so the inner
@@ -1280,7 +1290,8 @@ export function CenterPanel() {
         <button className="chrome-tab-new" onClick={handleAddTab}>
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
         </button>
-      </div>
+      </div>,
+      tabSlot)}
       <div className="main-content">
 
         {terminals.map(t => t.tool !== null ? (

--- a/src-ui/src/components/center/CenterPanel.tsx
+++ b/src-ui/src/components/center/CenterPanel.tsx
@@ -1296,7 +1296,7 @@ export function CenterPanel() {
             }}
           >
             {t.tool === 'history' ? (
-              <ChatReader sessionId={t.id} />
+              <ChatReader sessionId={t.id} showToast={showToast} />
             ) : t.tool === 'two-split' ? (
               <FourSplitGrid
                 tab={t}

--- a/src-ui/src/components/center/ChatReader.tsx
+++ b/src-ui/src/components/center/ChatReader.tsx
@@ -16,7 +16,12 @@ interface ChatMessage {
   turn_count?: number;
 }
 
-export function ChatReader({ sessionId }: { sessionId: string }) {
+interface ChatReaderProps {
+  sessionId: string;
+  showToast: (msg: string) => void;
+}
+
+export function ChatReader({ sessionId, showToast }: ChatReaderProps) {
   const t = useT();
   const { state, dispatch } = useAppState();
 
@@ -291,7 +296,10 @@ export function ChatReader({ sessionId }: { sessionId: string }) {
 
     commands.tierTerminalResume(
       currentSession.id, targetId, currentSession.tool, currentSession.session_token, 80, 24, currentSession.cwd
-    ).catch(console.error);
+    ).catch((err) => {
+      console.error(err);
+      showToast(`${t('history.resume_failed' as any)}${String(err)}`);
+    });
   };
 
   return (

--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -403,12 +403,6 @@ function TierTerminalImpl({
   const lastOutputAtRef = useRef(0);
   const [processExited, setProcessExited] = useState(false);
   const [startFailed, setStartFailed] = useState(false);
-  // First exit event to arrive (onExit from child-watcher, or onStatus from
-  // reader EOF) wins the right to write the "[Process exited]" scrollback
-  // line. Prevents duplication when both fire. The child-watcher's onExit
-  // typically arrives first with the real exit code; reader-EOF onStatus
-  // then arrives with a hardcoded 0 and correctly becomes a no-op.
-  const exitMessageWrittenRef = useRef(false);
   // Rolling buffer for agent-to-agent marker scanning. PTY chunks can split
   // `[COFFEE-TELL:...]` / `[COFFEE-DONE:...]` across boundaries; the buffer
   // reassembles chunks so markers match reliably. `markerScanOffsetRef`
@@ -886,31 +880,24 @@ function TierTerminalImpl({
             }
           }
         },
-        onStatus: (running, exitCode) => {
+        onStatus: (running, _exitCode) => {
           if (!mounted || running) return;
           setProcessExited(true);
           dispatch({ type: 'SET_AGENT_STATUS', id: sessionId, status: 'idle' });
-          if (exitMessageWrittenRef.current) return;
-          exitMessageWrittenRef.current = true;
-          const msg = exitCode === 0
-            ? '\r\n\x1b[32m[Process exited normally]\x1b[0m\r\n'
-            : `\r\n\x1b[31m[Process exited with code ${exitCode}]\x1b[0m\r\n`;
-          xtermRef.current?.write(msg);
         },
-        onExit: (exitCode) => {
+        onExit: (_exitCode) => {
           // Authoritative "process is actually dead" signal from the Rust
           // child-watcher thread. Critical for the lockup scenario where an
           // intermediate cmd.exe keeps the PTY slave open so reader never
           // sees EOF — without this, the terminal looked frozen forever.
+          //
+          // No banner written to the terminal on exit (tried this before —
+          // see git history — it read as Coffee CLI editorializing over the
+          // upstream tool's own output). The CLI's own exit text, if any,
+          // already speaks for itself.
           if (!mounted) return;
           setProcessExited(true);
           dispatch({ type: 'SET_AGENT_STATUS', id: sessionId, status: 'idle' });
-          if (exitMessageWrittenRef.current) return;
-          exitMessageWrittenRef.current = true;
-          const msg = exitCode === 0
-            ? '\r\n\x1b[32m[Process exited normally]\x1b[0m\r\n'
-            : `\r\n\x1b[31m[Process exited with code ${exitCode}]\x1b[0m\r\n`;
-          xtermRef.current?.write(msg);
         },
         onCwd: (cwd) => {
           if (!mounted) return;

--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -499,6 +499,30 @@ function TierTerminalImpl({
 
       term.open(termRef.current);
 
+      // ── Fix CJK IME punctuation duplication on Linux WebKitGTK (Tauri) ──
+      // On WebKitGTK + ibus, committing a CJK punctuation mark fires BOTH
+      // xterm's composition path (compositionstart/update/end) AND its input
+      // path, so each mark reaches the PTY twice and the whole run of
+      // punctuation re-accumulates on every keystroke (测试，，。。 …). We cut
+      // the composition path off at the source: capture-phase stopPropagation
+      // on the hidden helper textarea's three composition events means xterm's
+      // CompositionHelper never engages, leaving a single clean input path.
+      //
+      // __IS_LINUX__-gated on purpose — Chromium (Windows) / WKWebView (macOS)
+      // never had this bug and rely on CompositionHelper for normal IME, so we
+      // must not suppress it there. Ships on stable xterm 6.0.0 for every
+      // platform; replaces the earlier Linux-only 6.1.0-beta release artifact.
+      // Source: PR #38 / xtermjs#5374.
+      if (__IS_LINUX__) {
+        const imeTextarea = termRef.current.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null;
+        if (imeTextarea) {
+          const stopComposition = (e: Event) => e.stopPropagation();
+          imeTextarea.addEventListener('compositionstart', stopComposition, { capture: true });
+          imeTextarea.addEventListener('compositionupdate', stopComposition, { capture: true });
+          imeTextarea.addEventListener('compositionend', stopComposition, { capture: true });
+        }
+      }
+
       // Disable font ligatures on the DOM renderer rows to prevent
       // box-drawing characters from being merged into ligature glyphs.
       const xtermRows = termRef.current.querySelector('.xterm-rows') as HTMLElement | null;

--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -258,6 +258,86 @@ function TermContextMenu({ menu, onClose, onCopy, onPaste, onSelectAll }: {
   );
 }
 
+// ── Shared WebGL renderer budget ─────────────────────────────────────────────
+// Chromium/WebView2 caps *active* WebGL contexts at ~16 per renderer process.
+// With one terminal per tab/pane, a long session blows past that and the
+// browser force-loses the OLDEST context. We mirror VS Code's terminal (whose
+// team maintains xterm.js) with two process-wide guards:
+//   • `webglDisabled` latch — once ANY terminal fails to acquire, or loses, its
+//     GL context, every terminal that hasn't already attached (this one, if it
+//     just failed, + all future ones) renders via the DOM renderer instead.
+//     Terminals that already hold a live context keep it — the latch only
+//     stops new competition for a slot that isn't coming back. xterm
+//     auto-falls back to DOM when no render addon is loaded, so this degrades
+//     gracefully instead of stranding a tab on a dead renderer.
+//   • one cached GPU probe — the probe opens a throwaway GL context, so running
+//     it per-terminal wasted a context slot every time.
+let webglDisabled = false;
+let gpuIsHardware: boolean | null = null;
+
+function detectHardwareWebgl(): boolean {
+  try {
+    const testCanvas = document.createElement('canvas');
+    const gl = testCanvas.getContext('webgl') || testCanvas.getContext('experimental-webgl');
+    if (!gl) {
+      console.log('[TierTerminal] WebGL unavailable → DOM renderer');
+      return false;
+    }
+    const debugExt = (gl as WebGLRenderingContext).getExtension('WEBGL_debug_renderer_info');
+    if (!debugExt) {
+      // Privacy-hardened builds hide the renderer string; assume real hardware.
+      // (Defaulting to DOM here used to spike CPU on locked-down machines.)
+      console.log('[TierTerminal] GPU info hidden → WebGL (assuming hardware acceleration)');
+      return true;
+    }
+    const renderer = (gl as WebGLRenderingContext).getParameter(debugExt.UNMASKED_RENDERER_WEBGL) as string;
+    const isSoftware = /llvmpipe|softpipe|swrast|swiftshader|software|microsoft basic render|mesa offscreen/i.test(renderer);
+    console.log(`[TierTerminal] GPU: ${renderer} → ${isSoftware ? 'DOM' : 'WebGL'} (software=${isSoftware})`);
+    return !isSoftware;
+  } catch {
+    console.warn('[TierTerminal] WebGL probe failed → DOM renderer');
+    return false;
+  }
+}
+
+function probeWebglOnce(): boolean {
+  if (gpuIsHardware === null) gpuIsHardware = detectHardwareWebgl();
+  return gpuIsHardware;
+}
+
+// Attach the WebGL renderer to `term`, respecting the shared context budget.
+// Idempotent per terminal (guards on `webglRef`); a no-op once the latch is
+// tripped or on a software GPU. Safe to call on first reveal, so a tab that is
+// never shown never spends a context. DOM fallback loses customGlyphs /
+// rescaleOverlappingGlyphs, so box-drawing may misalign on degraded terminals.
+function attachWebglRenderer(
+  term: Terminal,
+  webglRef: { current: WebglAddon | null },
+): void {
+  if (webglDisabled || webglRef.current) return;
+  if (!probeWebglOnce()) return; // software GPU → DOM renderer is cheaper
+  try {
+    const webgl = new WebglAddon();
+    webgl.onContextLoss(() => {
+      // Browser force-loses a context when the ~16 cap is hit or the GPU driver
+      // resets. Drop THIS terminal's renderer and latch the budget so no FUTURE
+      // terminal competes for a slot that isn't coming back. Terminals that
+      // already hold a live context (attached before this loss) are left
+      // alone — revoking a still-working context would be more destructive
+      // than the problem this is solving.
+      webglDisabled = true;
+      try { webgl.dispose(); } catch { /* already gone */ }
+      webglRef.current = null;
+    });
+    term.loadAddon(webgl);
+    webglRef.current = webgl;
+  } catch (err) {
+    // No context available even now → give up on WebGL process-wide.
+    webglDisabled = true;
+    console.error('[TierTerminal] WebGL attach failed → DOM renderer', err);
+  }
+}
+
 interface TierTerminalProps {
   sessionId: string;
   tool: ToolType;
@@ -303,6 +383,7 @@ function TierTerminalImpl({
   const wrapRef  = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
   const fitRef   = useRef<FitAddon | null>(null);
+  const webglRef = useRef<WebglAddon | null>(null);
 
   // ── Startup splash state ─────────────────────────────────────────────────
   const [showSplash, setShowSplash] = useState(true);
@@ -440,43 +521,38 @@ function TierTerminalImpl({
     // M-series, Intel Iris Xe, AMD APU) handle xterm WebGL fine; the
     // older "dedicated-GPU only" gate was misclassifying Apple Silicon
     // and Intel UHD laptops as DOM-only and tanking their CPU.
-    let useWebgl = false;
-    try {
-      const testCanvas = document.createElement('canvas');
-      const gl = testCanvas.getContext('webgl') || testCanvas.getContext('experimental-webgl');
-      if (gl) {
-        const debugExt = (gl as WebGLRenderingContext).getExtension('WEBGL_debug_renderer_info');
-        if (debugExt) {
-          const renderer = (gl as WebGLRenderingContext).getParameter(debugExt.UNMASKED_RENDERER_WEBGL) as string;
-          const isSoftware = /llvmpipe|softpipe|swrast|swiftshader|software|microsoft basic render|mesa offscreen/i.test(renderer);
-          useWebgl = !isSoftware;
-          console.log(`[TierTerminal] GPU: ${renderer} → ${useWebgl ? 'WebGL' : 'DOM'} (software=${isSoftware})`);
-        } else {
-          // No debug extension — assume the GPU is real. Modern browsers
-          // hide UNMASKED_RENDERER_WEBGL behind a privacy flag in some
-          // contexts; defaulting to DOM here was the old behavior and
-          // caused the same per-window CPU spike on locked-down builds.
-          useWebgl = true;
-          console.log('[TierTerminal] GPU info hidden → WebGL (assuming hardware acceleration)');
+    // WebGL is a scarce shared resource (Chromium caps it at ~16 contexts; see
+    // attachWebglRenderer). Only spend a context once this terminal is actually
+    // on-screen, so tabs opened but never viewed cost zero context. Kept once
+    // attached (no renderer thrash on tab switch, matching VS Code's terminal).
+    // This laziness is per-TAB, not per-pane: a split tab (FourSplitGrid) dims
+    // its inactive panes with opacity, not display:none, so every pane in an
+    // ACTIVE split tab already has offsetParent set and attaches WebGL
+    // synchronously below — a 4-pane split alone can spend 4 of the ~16
+    // budget the moment it's opened. The shared latch still caps the damage
+    // (falls back to DOM once exhausted); this just isn't "lazy" within a
+    // split the way it is across tabs.
+    if (termRef.current!.offsetParent !== null) {
+      // Already on-screen — the common case: a freshly-opened active tab.
+      // Attach synchronously so the tab you're looking at never shows a
+      // one-frame DOM→WebGL swap.
+      attachWebglRenderer(term, webglRef);
+    } else {
+      // Created while hidden (background/restored tab, or a split pane whose
+      // tab isn't shown). Attach on first reveal. Element-level visibility is
+      // correct for both single tabs and split panes (all visible panes
+      // intersect), unlike the focus-scoped `isActive` prop. One-shot.
+      const webglIO = new IntersectionObserver((entries) => {
+        // `mounted` guards a dispose race: a queued callback firing after the
+        // effect cleanup would loadAddon() onto a disposed terminal, and the
+        // catch inside attachWebglRenderer would wrongly trip the latch to DOM.
+        if (mounted && entries.some((e) => e.isIntersecting)) {
+          attachWebglRenderer(term, webglRef);
+          webglIO.disconnect();
         }
-      } else {
-        console.log('[TierTerminal] WebGL unavailable → DOM renderer');
-      }
-    } catch {
-      console.warn('[TierTerminal] WebGL probe failed → DOM renderer');
-    }
-
-    // Always use WebGL renderer when possible — DOM renderer does NOT support
-    // customGlyphs or rescaleOverlappingGlyphs, causing ASCII art (Claude mascot,
-    // box borders) to misalign. WebGL supports allowTransparency for wallpapers.
-    if (useWebgl) {
-      try {
-        const webgl = new WebglAddon();
-        webgl.onContextLoss(() => { webgl.dispose(); });
-        term.loadAddon(webgl);
-      } catch (err) {
-        console.error('[TierTerminal] WebGL instantiation failed, falling back to DOM renderer', err);
-      }
+      });
+      webglIO.observe(termRef.current!);
+      unlisteners.push(() => webglIO.disconnect());
     }
 
     fit.fit();
@@ -851,6 +927,32 @@ function TierTerminalImpl({
 
         await commands.tierTerminalStart(sessionId, tool, initialCols, initialRows, theme, lang, toolData, folderPath ?? undefined);
 
+        // Continuously report on-screen visibility to the backend so its
+        // emitter can widen its coalesce window for a tab that's open but not
+        // the one being looked at — independent of whole-window
+        // BACKGROUND_MODE, which only covers the OS-hidden case. Unlike the
+        // one-shot WebGL observer above, this one never disconnects: it flips
+        // every tab switch for the life of the session. Placed after
+        // tierTerminalStart resolves (not earlier, alongside the WebGL
+        // observer) so the backend session is guaranteed to exist before the
+        // first report — a race would otherwise silently drop it and this
+        // session would default to full-cadence forever.
+        if (mounted && termRef.current) {
+          const visibilityIO = new IntersectionObserver((entries) => {
+            // Re-check `mounted` inside the callback (not just at registration
+            // above): IntersectionObserver callbacks are delivered via the
+            // browser's rendering-update step, not synchronously with
+            // disconnect(), so one can still be in flight when cleanup runs.
+            // Backend no-ops on an unknown session either way, but matching
+            // the WebGL observer's discipline keeps this from firing at all.
+            if (!mounted) return;
+            const visible = entries.some((e) => e.isIntersecting);
+            commands.setSessionActive(sessionId, visible).catch(() => {});
+          });
+          visibilityIO.observe(termRef.current);
+          unlisteners.push(() => visibilityIO.disconnect());
+        }
+
         // After PTY is running, wait two frames for layout to settle then
         // send the true terminal size. This fixes TUI adaptive-width tools
         // (Claude Code, etc.) that respond to SIGWINCH — the initial fit may
@@ -904,6 +1006,7 @@ function TierTerminalImpl({
       ro.disconnect();
       term.dispose();
       xtermRef.current = null;
+      webglRef.current = null;
       unlisteners.forEach(u => u());
       // Skip kill if this session was detached to a new window
       if (detachedSessions.has(sessionId)) {

--- a/src-ui/src/components/common/SettingsModal.css
+++ b/src-ui/src/components/common/SettingsModal.css
@@ -366,6 +366,54 @@
 .settings-lang-check { display: flex; color: var(--accent, #c4956a); }
 .settings-lang-check svg { width: 14px; height: 14px; }
 
+/* ── Feedback (Bug / suggestions) ──────────────────────────────────────── */
+.settings-feedback-desc {
+  margin: 0 0 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-2, rgba(255, 255, 255, 0.7));
+}
+.settings-feedback-cards { display: flex; gap: 12px; }
+.settings-feedback-card {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 92px;
+  padding: 20px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: transparent;
+  border-radius: var(--radius-md, 12px);
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.14s ease;
+}
+.settings-feedback-card:hover {
+  border-color: var(--accent, #c4956a);
+  background: color-mix(in srgb, var(--accent, #c4956a) 8%, transparent);
+}
+.settings-feedback-card-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--text-1, #fff);
+}
+.settings-feedback-card-icon svg { width: 26px; height: 26px; }
+.settings-feedback-card-label { font-size: 20px; font-weight: 600; color: var(--text-1, #fff); }
+.settings-feedback-card-arrow {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 15px;
+  height: 15px;
+  color: var(--text-3, rgba(255, 255, 255, 0.4));
+  transition: color 0.14s ease;
+}
+.settings-feedback-card:hover .settings-feedback-card-arrow { color: var(--accent, #c4956a); }
+
 /* ── Terminal font picker (custom themed dropdown) ─────────────────────── */
 .settings-font-trigger {
   display: flex;

--- a/src-ui/src/components/common/SettingsModal.tsx
+++ b/src-ui/src/components/common/SettingsModal.tsx
@@ -22,7 +22,14 @@ import { FontPicker } from './FontPicker';
 import { THEME_COLORS, THEME_SHAPES, ICON_ART_THEMES, LANGUAGES, TASK_VIEW_MODES, isMaskTintTheme } from '../../lib/personalization';
 import './SettingsModal.css';
 
-type Section = 'appearance' | 'wallpaper' | 'terminal' | 'gambit' | 'tasks' | 'language';
+type Section = 'appearance' | 'wallpaper' | 'terminal' | 'gambit' | 'tasks' | 'language' | 'feedback';
+
+// Trailing "opens outside the app" affordance on the feedback cards.
+const ExternalLinkArrow = () => (
+  <svg className="settings-feedback-card-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M7 17 17 7" /><path d="M7 7h10v10" />
+  </svg>
+);
 
 // Per-mode preview glyphs for the Tasks section (checklist vs sticky note).
 const TASK_VIEW_ICONS: Record<'list' | 'note', ReactNode> = {
@@ -73,6 +80,15 @@ const ICONS: Record<Section, ReactNode> = {
   language: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
       <circle cx="12" cy="12" r="10" /><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" /><path d="M2 12h20" />
+    </svg>
+  ),
+  feedback: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" />
+      <path d="M9 7.13V6a3 3 0 1 1 6 0v1.13" />
+      <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6Z" />
+      <path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M6 17c-1.7 0-3 1.3-3 3" />
+      <path d="M17.47 9c1.93-.2 3.53-1.9 3.53-4" /><path d="M18 13h4" /><path d="M18 17c1.7 0 3 1.3 3 3" />
     </svg>
   ),
 };
@@ -181,6 +197,7 @@ export function SettingsModal() {
     { id: 'gambit',     label: t('settings.gambit' as any) },
     { id: 'tasks',      label: t('settings.tasks' as any) },
     { id: 'language',   label: t('settings.language' as any) },
+    { id: 'feedback',   label: t('settings.feedback' as any) },
   ];
   const currentLabel = SECTIONS.find(s => s.id === section)?.label ?? '';
 
@@ -429,6 +446,37 @@ export function SettingsModal() {
                   </button>
                 ))}
               </div>
+            )}
+
+            {section === 'feedback' && (
+              <>
+                <p className="settings-feedback-desc">{t('settings.feedback.desc' as any)}</p>
+                <div className="settings-feedback-cards">
+                  <button
+                    type="button"
+                    className="settings-feedback-card"
+                    onClick={() => commands.openUrl('https://github.com/edison7009/Coffee-CLI/issues').catch(() => {})}
+                  >
+                    <span className="settings-feedback-card-icon">
+                      <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+                      </svg>
+                    </span>
+                    <span className="settings-feedback-card-label">GitHub</span>
+                    <ExternalLinkArrow />
+                  </button>
+                  {state.currentLang === 'zh-CN' && (
+                    <button
+                      type="button"
+                      className="settings-feedback-card"
+                      onClick={() => commands.openUrl('https://gitcode.com/edison7009/Coffee-CLI/issues').catch(() => {})}
+                    >
+                      <span className="settings-feedback-card-label">国内访问：GitCode</span>
+                      <ExternalLinkArrow />
+                    </button>
+                  )}
+                </div>
+              </>
             )}
           </div>
         </section>

--- a/src-ui/src/components/common/TitleBar.tsx
+++ b/src-ui/src/components/common/TitleBar.tsx
@@ -48,6 +48,9 @@ export function TitleBar() {
   const onDragMouseDown = async (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.button !== 0) return;
     if ((e.target as HTMLElement).closest('button')) return;
+    // Tool tabs now live in the bar — a press on the tab strip must reach the
+    // tab's own click / pointer-reorder handlers, not start a window drag.
+    if ((e.target as HTMLElement).closest('.chrome-tabs-header')) return;
     e.preventDefault();
     if (!isTauri) return;
     try {
@@ -57,11 +60,24 @@ export function TitleBar() {
   };
   const onDragDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if ((e.target as HTMLElement).closest('button')) return;
+    if ((e.target as HTMLElement).closest('.chrome-tabs-header')) return;
     maximize();
   };
 
   return (
     <div className="titlebar" onMouseDown={onDragMouseDown} onDoubleClick={onDragDoubleClick}>
+      {/* Left slot mirrors the left panel's width so the tab strip begins at
+          the TOP OF THE CENTER COLUMN, not the window's left edge — that
+          far-left strip belongs to the left sidebar (and hosts the macOS
+          traffic lights). Collapses in lockstep with the panel via the shared
+          --w-left var + the same 250ms curve. */}
+      <div className={`titlebar-left-slot${state.leftPanelHidden ? ' is-collapsed' : ''}`} />
+      {/* Tool tabs (Windows-Terminal style) render here — CenterPanel portals
+          its .chrome-tabs-header into this slot so the tabs sit on the drag bar
+          above the center column, with the layout toggles + window controls to
+          their right. The flexible spacer between them stays a draggable handle. */}
+      <div className="titlebar-tabs" id="titlebar-tab-slot" />
+      <div className="titlebar-drag-spacer" />
       {/* Icons come straight from Lucide (lucide.dev, ISC license). No
           runtime dependency — just the d-paths copied inline so we
           don't pay a 200KB+ import for four glyphs.

--- a/src-ui/src/i18n/de.ts
+++ b/src-ui/src/i18n/de.ts
@@ -98,6 +98,8 @@ export const de = {
   'settings.terminal': 'Terminal',
   'settings.gambit': 'Gambit',
   'settings.language': 'Sprache',
+  'settings.feedback': 'Fehler & Feedback',
+  'settings.feedback.desc': 'Einen Fehler gefunden oder einen Vorschlag? Klicke unten, um dein Problem zu melden:',
   'settings.wallpaper.pick': 'Bild oder Video wählen',
   'settings.wallpaper.clear': 'Hintergrund entfernen',
   'settings.wallpaper.opacity': 'Deckkraft',

--- a/src-ui/src/i18n/de.ts
+++ b/src-ui/src/i18n/de.ts
@@ -81,6 +81,7 @@ export const de = {
 
   // Actions
   'action.resume_terminal': 'Diese Sitzung fortsetzen',
+  'history.resume_failed': 'Sitzung konnte nicht fortgesetzt werden: ',
 
   // Time
   'time.just_now': 'Gerade eben',

--- a/src-ui/src/i18n/en.ts
+++ b/src-ui/src/i18n/en.ts
@@ -98,6 +98,8 @@ export const en = {
   'settings.wallpaper': 'Wallpaper',
   'settings.terminal': 'Terminal',
   'settings.language': 'Language',
+  'settings.feedback': 'Bug / Feedback',
+  'settings.feedback.desc': 'Found a bug or have a suggestion? Click below to submit your issue:',
   'settings.wallpaper.pick': 'Choose image or video',
   'settings.wallpaper.clear': 'Remove wallpaper',
   'settings.wallpaper.opacity': 'Opacity',

--- a/src-ui/src/i18n/en.ts
+++ b/src-ui/src/i18n/en.ts
@@ -82,6 +82,7 @@ export const en = {
 
   // Actions
   'action.resume_terminal': 'Continue this session',
+  'history.resume_failed': 'Resume failed: ',
 
   // Time
   'time.just_now': 'Just now',

--- a/src-ui/src/i18n/es.ts
+++ b/src-ui/src/i18n/es.ts
@@ -97,6 +97,8 @@ export const es = {
   'settings.terminal': 'Terminal',
   'settings.gambit': 'Gambit',
   'settings.language': 'Idioma',
+  'settings.feedback': 'Errores y sugerencias',
+  'settings.feedback.desc': '¿Encontraste un error o tienes una sugerencia? Haz clic abajo para enviar tu problema:',
   'settings.wallpaper.pick': 'Elegir imagen o vídeo',
   'settings.wallpaper.clear': 'Quitar fondo',
   'settings.wallpaper.opacity': 'Opacidad',

--- a/src-ui/src/i18n/es.ts
+++ b/src-ui/src/i18n/es.ts
@@ -80,6 +80,7 @@ export const es = {
 
   // Actions
   'action.resume_terminal': 'Continuar esta sesión',
+  'history.resume_failed': 'Error al reanudar la sesión: ',
 
   // Time
   'time.just_now': 'Ahora mismo',

--- a/src-ui/src/i18n/fr.ts
+++ b/src-ui/src/i18n/fr.ts
@@ -97,6 +97,8 @@ export const fr = {
   'settings.terminal': 'Terminal',
   'settings.gambit': 'Gambit',
   'settings.language': 'Langue',
+  'settings.feedback': 'Bugs et suggestions',
+  'settings.feedback.desc': 'Vous avez trouvé un bug ou avez une suggestion ? Cliquez ci-dessous pour soumettre votre problème :',
   'settings.wallpaper.pick': 'Choisir une image ou une vidéo',
   'settings.wallpaper.clear': "Supprimer le fond d'écran",
   'settings.wallpaper.opacity': 'Opacité',

--- a/src-ui/src/i18n/fr.ts
+++ b/src-ui/src/i18n/fr.ts
@@ -80,6 +80,7 @@ export const fr = {
 
   // Actions
   'action.resume_terminal': 'Reprendre cette session',
+  'history.resume_failed': 'Échec de la reprise de la session : ',
 
   // Time
   'time.just_now': 'À l\u2019instant',

--- a/src-ui/src/i18n/ja.ts
+++ b/src-ui/src/i18n/ja.ts
@@ -80,6 +80,7 @@ export const ja = {
 
   // Actions
   'action.resume_terminal': 'このセッションを続ける',
+  'history.resume_failed': 'セッションの再開に失敗しました：',
 
   // Time
   'time.just_now': 'たった今',

--- a/src-ui/src/i18n/ja.ts
+++ b/src-ui/src/i18n/ja.ts
@@ -97,6 +97,8 @@ export const ja = {
   'settings.terminal': 'ターミナル',
   'settings.gambit': '一手',
   'settings.language': '言語',
+  'settings.feedback': 'バグ・フィードバック',
+  'settings.feedback.desc': 'バグを見つけた、またはご提案がある場合は、下のリンクから内容を送信してください：',
   'settings.wallpaper.pick': '画像または動画を選択',
   'settings.wallpaper.clear': '壁紙を削除',
   'settings.wallpaper.opacity': '不透明度',

--- a/src-ui/src/i18n/ko.ts
+++ b/src-ui/src/i18n/ko.ts
@@ -80,6 +80,7 @@ export const ko = {
 
   // Actions
   'action.resume_terminal': '이 세션 계속하기',
+  'history.resume_failed': '세션 재개 실패: ',
 
   // Time
   'time.just_now': '방금',

--- a/src-ui/src/i18n/ko.ts
+++ b/src-ui/src/i18n/ko.ts
@@ -97,6 +97,8 @@ export const ko = {
   'settings.terminal': '터미널',
   'settings.gambit': '한 수',
   'settings.language': '언어',
+  'settings.feedback': '버그 / 피드백',
+  'settings.feedback.desc': '버그를 발견했거나 제안이 있으신가요? 아래를 클릭해 문제를 제출해 주세요:',
   'settings.wallpaper.pick': '이미지 또는 동영상 선택',
   'settings.wallpaper.clear': '배경화면 제거',
   'settings.wallpaper.opacity': '불투명도',

--- a/src-ui/src/i18n/pt.ts
+++ b/src-ui/src/i18n/pt.ts
@@ -98,6 +98,8 @@ export const pt = {
   'settings.terminal': 'Terminal',
   'settings.gambit': 'Gambit',
   'settings.language': 'Idioma',
+  'settings.feedback': 'Bugs e sugestões',
+  'settings.feedback.desc': 'Encontrou um bug ou tem uma sugestão? Clique abaixo para enviar seu problema:',
   'settings.wallpaper.pick': 'Escolher imagem ou vídeo',
   'settings.wallpaper.clear': 'Remover papel de parede',
   'settings.wallpaper.opacity': 'Opacidade',

--- a/src-ui/src/i18n/pt.ts
+++ b/src-ui/src/i18n/pt.ts
@@ -81,6 +81,7 @@ export const pt = {
 
   // Actions
   'action.resume_terminal': 'Continuar esta sessão',
+  'history.resume_failed': 'Falha ao retomar a sessão: ',
 
   // Time
   'time.just_now': 'Agora mesmo',

--- a/src-ui/src/i18n/ru.ts
+++ b/src-ui/src/i18n/ru.ts
@@ -98,6 +98,8 @@ export const ru = {
   'settings.terminal': 'Терминал',
   'settings.gambit': 'Gambit',
   'settings.language': 'Язык',
+  'settings.feedback': 'Баги и предложения',
+  'settings.feedback.desc': 'Нашли баг или есть предложение? Нажмите ниже, чтобы отправить проблему:',
   'settings.wallpaper.pick': 'Выбрать изображение или видео',
   'settings.wallpaper.clear': 'Убрать обои',
   'settings.wallpaper.opacity': 'Непрозрачность',

--- a/src-ui/src/i18n/ru.ts
+++ b/src-ui/src/i18n/ru.ts
@@ -81,6 +81,7 @@ export const ru = {
 
   // Actions
   'action.resume_terminal': 'Продолжить сессию',
+  'history.resume_failed': 'Не удалось возобновить сессию: ',
 
   // Time
   'time.just_now': 'Только что',

--- a/src-ui/src/i18n/vi.ts
+++ b/src-ui/src/i18n/vi.ts
@@ -100,6 +100,8 @@ export const vi = {
   'settings.terminal': 'Terminal',
   'settings.gambit': 'Nước cờ',
   'settings.language': 'Ngôn ngữ',
+  'settings.feedback': 'Lỗi & Góp ý',
+  'settings.feedback.desc': 'Gặp lỗi hoặc có góp ý? Nhấp vào bên dưới để gửi vấn đề của bạn:',
   'settings.wallpaper.pick': 'Chọn ảnh hoặc video',
   'settings.wallpaper.clear': 'Xóa hình nền',
   'settings.wallpaper.opacity': 'Độ mờ',

--- a/src-ui/src/i18n/vi.ts
+++ b/src-ui/src/i18n/vi.ts
@@ -83,6 +83,7 @@ export const vi = {
 
   // Actions
   'action.resume_terminal': 'Tiếp tục phiên này',
+  'history.resume_failed': 'Không thể tiếp tục phiên: ',
 
   // Time
   'time.just_now': 'Vừa xong',

--- a/src-ui/src/i18n/zh-CN.ts
+++ b/src-ui/src/i18n/zh-CN.ts
@@ -80,6 +80,7 @@ export const zhCN = {
 
   // Actions
   'action.resume_terminal': '继续本轮对话',
+  'history.resume_failed': '恢复会话失败：',
 
   // Time
   'time.just_now': '刚刚',

--- a/src-ui/src/i18n/zh-CN.ts
+++ b/src-ui/src/i18n/zh-CN.ts
@@ -96,6 +96,8 @@ export const zhCN = {
   'settings.wallpaper': '壁纸',
   'settings.terminal': '终端',
   'settings.language': '语言',
+  'settings.feedback': 'BUG / 建议',
+  'settings.feedback.desc': '遇到 BUG 或建议，点击下方提交你的问题：',
   'settings.wallpaper.pick': '选择图片或视频',
   'settings.wallpaper.clear': '移除壁纸',
   'settings.wallpaper.opacity': '透明度',

--- a/src-ui/src/i18n/zh-TW.ts
+++ b/src-ui/src/i18n/zh-TW.ts
@@ -96,6 +96,8 @@ export const zhTW = {
   'settings.wallpaper': '桌布',
   'settings.terminal': '終端',
   'settings.language': '語言',
+  'settings.feedback': 'BUG / 建議',
+  'settings.feedback.desc': '遇到 BUG 或建議，點擊下方提交你的問題：',
   'settings.wallpaper.pick': '選擇圖片或影片',
   'settings.wallpaper.clear': '移除桌布',
   'settings.wallpaper.opacity': '透明度',

--- a/src-ui/src/i18n/zh-TW.ts
+++ b/src-ui/src/i18n/zh-TW.ts
@@ -80,6 +80,7 @@ export const zhTW = {
 
   // Actions
   'action.resume_terminal': '繼續此次對話',
+  'history.resume_failed': '恢復對話失敗：',
 
   // Time
   'time.just_now': '剛剛',

--- a/src-ui/src/styles/global.css
+++ b/src-ui/src/styles/global.css
@@ -299,7 +299,6 @@ textarea,
        triplet keeps the shadow readable while still feeling on-palette. */
     --shadow-rgb: 196, 149, 106;
 
-    --bg-titlebar: rgba(0, 0, 0, 0.1);
     --bg-terminal: #1a1917; /* Match bg-app — unified surface rule across themes */
 }
 
@@ -343,7 +342,6 @@ textarea,
        coloured shadow that the dark themes use. */
     --shadow-rgb: 0, 0, 0;
 
-    --bg-titlebar: rgba(0, 0, 0, 0.03);
     --bg-terminal: #eeebe2; /* Soft cream — slightly darker than ivory body
                                so terminal reads as a recessed workspace
                                between the two brighter side panels. */
@@ -380,7 +378,6 @@ textarea,
     --shadow-rgb: 160, 160, 160;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.35);
     --bg-terminal: #1a1a1a; /* Match bg-app */
 }
 
@@ -415,7 +412,6 @@ textarea,
     --shadow-rgb: 248, 180, 200;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.15);
     --bg-terminal: #1a1520; /* Match bg-app */
 }
 
@@ -450,7 +446,6 @@ textarea,
     --shadow-rgb: 200, 182, 255;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.15);
     --bg-terminal: #1a1826; /* Match bg-app */
 }
 
@@ -485,7 +480,6 @@ textarea,
     --shadow-rgb: 122, 232, 200;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.15);
     --bg-terminal: #0f1e1c; /* Match bg-app */
 }
 
@@ -523,7 +517,6 @@ textarea,
     --shadow-rgb: 160, 160, 160;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.4);
     --bg-terminal: #0a0a0a; /* Match bg-app */
 }
 
@@ -561,7 +554,6 @@ textarea,
     --shadow-rgb: 90, 133, 184;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.28);
     --bg-terminal: #0a1020; /* Match bg-app */
 }
 
@@ -599,7 +591,6 @@ textarea,
     --shadow-rgb: 106, 152, 120;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.24);
     --bg-terminal: #0b1612; /* Match bg-app */
 }
 
@@ -645,7 +636,6 @@ textarea,
     --shadow-rgb: 226, 59, 66;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.2);
     --bg-terminal: #2a0d10; /* Match bg-app */
 }
 
@@ -680,7 +670,6 @@ textarea,
     --shadow-rgb: 245, 128, 59;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.18);
     --bg-terminal: #241408; /* Match bg-app */
 }
 
@@ -715,7 +704,6 @@ textarea,
     --shadow-rgb: 232, 167, 44;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.18);
     --bg-terminal: #20180a; /* Match bg-app */
 }
 
@@ -750,7 +738,6 @@ textarea,
     --shadow-rgb: 36, 194, 129;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.22);
     --bg-terminal: #0a1c12; /* Match bg-app */
 }
 
@@ -785,7 +772,6 @@ textarea,
     --shadow-rgb: 43, 196, 196;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.22);
     --bg-terminal: #0a2125; /* Match bg-app */
 }
 
@@ -820,7 +806,6 @@ textarea,
     --shadow-rgb: 97, 114, 240;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.22);
     --bg-terminal: #12142e; /* Match bg-app */
 }
 
@@ -855,7 +840,6 @@ textarea,
     --shadow-rgb: 217, 74, 160;
     --glass-blur: blur(24px);
 
-    --bg-titlebar: rgba(0, 0, 0, 0.2);
     --bg-terminal: #210f1d; /* Match bg-app */
 }
 
@@ -921,20 +905,64 @@ html.is-macos #root {
 /* ─── Custom Titlebar ────────────────────────────────── */
 .titlebar {
     height: 32px;
-    background: var(--bg-titlebar);
+    /* Same surface as the side panels (--bg-panel), so the titlebar + left rail
+       + right rail read as one continuous "brighter frame" around the darker
+       terminal centre. The active tab (--bg-terminal, darker) then sits as a
+       recessed notch that seams into the content below. Ties to --bg-panel so
+       every theme aligns automatically; the old per-theme --bg-titlebar token
+       is now unused. */
+    background: var(--bg-panel);
     display: flex;
-    /* Layout toggles + window controls group to the right; the whole
-       left side stays draggable. Matches VS Code / JetBrains: chrome
-       clusters on one side, the rest is grab-handle.
+    /* Tool tabs (left) → flexible drag spacer → layout toggles + window
+       controls (right). The spacer is the grab-handle between the tabs and
+       the controls.
 
        Drag mechanism: see TitleBar.tsx — single JS `onMouseDown` ->
-       `startDragging()` path. Do NOT add `-webkit-app-region: drag`
-       here; it races Tauri's drag and stalls paint on direction
+       `startDragging()` path, which bails on <button> AND .chrome-tabs-header
+       so tab clicks / pointer-reorder win. Do NOT add `-webkit-app-region:
+       drag` here; it races Tauri's drag and stalls paint on direction
        reversal. */
-    justify-content: flex-end;
-    align-items: center;
+    align-items: stretch;
     user-select: none;
     flex-shrink: 0;
+}
+
+/* Tool-tab strip slot — CenterPanel portals its .chrome-tabs-header in here so
+   the tabs live on the drag bar (Windows-Terminal style), not a row below it. */
+/* Left slot — mirrors .panel-left's width (same --w-left var + 250ms curve) so
+   the tab strip starts at the top of the CENTER column, not the window edge.
+   That far-left strip is the left sidebar's domain / the macOS traffic lights.
+   Empty and draggable. */
+.titlebar-left-slot {
+    width: var(--w-left);
+    flex-shrink: 0;
+    height: 100%;
+    transition: width 250ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.titlebar-left-slot.is-collapsed {
+    width: 0;
+}
+/* macOS EDGE CASE: when the left panel is hidden this slot would collapse to 0
+   and the tabs would slide under the native traffic lights (top-left). Keep a
+   fixed inset so the tabs stay pushed right of them. The lights start at
+   trafficLightPosition x:14 (tauri.macos.conf.json) and span ~52px → end ~66px;
+   80px leaves a comfortable gap. (Panel SHOWN needs no special case — the slot
+   is then --w-left ≥ 320px, well clear of the lights.) Real-Mac verify pending. */
+html.is-macos .titlebar-left-slot.is-collapsed {
+    width: 80px;
+}
+
+.titlebar-tabs {
+    display: flex;
+    align-items: stretch;
+    min-width: 0;
+    height: 100%;
+}
+/* Flexible grab-handle filling the gap between the tabs and the right cluster. */
+.titlebar-drag-spacer {
+    flex: 1 1 auto;
+    min-width: 32px;
+    height: 100%;
 }
 
 /* Layout toggles sit flush against the window controls — same visual
@@ -946,6 +974,7 @@ html.is-macos #root {
     display: flex;
     align-items: center;
     height: 100%;
+    flex-shrink: 0; /* never shrink the right cluster — tabs + spacer absorb it */
 }
 
 .titlebar-btn--layout {
@@ -968,6 +997,7 @@ html.is-macos #root {
 .titlebar-controls {
     display: flex;
     height: 100%;
+    flex-shrink: 0; /* window controls must never be clipped by a full tab row */
 }
 
 .titlebar-btn {
@@ -1591,6 +1621,16 @@ body.gambit-docked .chat-reader-container {
     color: var(--text-1);
 }
 
+/* Chrome-tabs moved into the titlebar — OUTSIDE the `.panel-*` nuclear rule
+   (above) that used to strip their background in the transparent shapes. So
+   re-strip here: every tab (active + hover included) stays fully transparent
+   and shows the body's single --glass-tint / carbon mesh, instead of stacking
+   an opaque --bg-terminal fill. The active tab is distinguished by brighter
+   text (rule above / --text-1), not a fill — the glass "no local layer" rule. */
+:is([data-shape="glass"], [data-shape="carbon"]) .chrome-tab {
+    background: transparent !important;
+}
+
 /* Library segmented toggle (Agents / Skills above the launchpad
    grid). Container becomes a faint glass pill; the active segment
    inside reads as "lit-up brighter glass" instead of the source-
@@ -1794,7 +1834,6 @@ body.gambit-docked .chat-reader-container {
     --bg-card: var(--bg-app);
     --bg-input: var(--bg-app);
     --bg-input-focus: var(--bg-app);
-    --bg-titlebar: var(--bg-app);
     --bg-terminal: var(--bg-app);
     /* Brighter border so dividers actually read on a same-color field;
        otherwise the default --border (~4% alpha) vanishes. */
@@ -1854,32 +1893,20 @@ body.gambit-docked .chat-reader-container {
     color: var(--text-1);
 }
 
-/* ─── Center pane chrome-tabs + main-content as one drawn box ───
-   Active tab: 3-side outline (top, left, right) — bottom merges
-   into the content area below by overlapping the header divider.
-   Content area: left/right/bottom borders form the rest of the
-   enclosure; the chrome-tabs-header's border-bottom is the top. */
-[data-shape="panel"] .chrome-tabs-header {
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 0;
-}
+/* ─── Panel shape: chrome-tabs now live in the titlebar ───
+   The titlebar's own border-bottom (see `[data-shape="panel"] .titlebar` above)
+   is the single divider / top edge of the content box. The ACTIVE tab breaks
+   through it (−1px bottom) so its --bg-app fill seams into main-content below —
+   the "terminal-tube" merge — with a 3-side outline (top/left/right) framing
+   it; inactive tabs just sit in the bar.
 
-/* All tabs (active + inactive) get the same -1px bottom margin in panel
-   mode. Two reasons:
-   1. The active tab's bg covers the chrome-tabs-header's border-bottom
-      directly under it — the "tab merges into content" terminal-tube look.
-   2. With ALL tabs (not just active) sharing the same margin-box height,
-      the chrome-tabs-header's intrinsic flex cross-size stays stable at
-      37px regardless of which tab is active or how many tabs exist.
-      Otherwise the container would grow 1px when going from 1-tab to
-      2-tabs (max child margin-box: 37 → 38), pushing main-content down
-      1px and visibly misaligning the active tab's top edge with the
-      Explorer panel header on the left. */
-[data-shape="panel"] .chrome-tab {
-    margin-bottom: -1px;
-}
-
+   Previously .chrome-tabs-header carried its OWN border-bottom and EVERY tab a
+   −1px margin, because the strip sat directly above main-content in the center
+   column. Both are gone now: with the strip in the titlebar, the header border
+   stacked under the titlebar border as one chunky 2px line, and its border-box
+   ate 1px off the tab height (the "line too thick / top −1px" report). */
 [data-shape="panel"] .chrome-tab.active {
+    margin-bottom: -1px;
     background: var(--bg-app);
     box-shadow:
         inset 0 1px 0 0 var(--border),     /* top */

--- a/src-ui/src/tauri.ts
+++ b/src-ui/src/tauri.ts
@@ -124,6 +124,13 @@ export const commands = {
   setBackgroundMode: (hidden: boolean) =>
     invoke<void>('set_background_mode', { hidden }),
 
+  /** Per-tab visibility signal — narrower than setBackgroundMode. Flip when
+   *  this session's terminal element enters/leaves the viewport (a tab
+   *  switch, not just the whole window hiding) so its backend emitter can
+   *  widen its coalesce window while nobody is looking at that tab. */
+  setSessionActive: (sessionId: string, active: boolean) =>
+    invoke<void>('set_session_active', { sessionId, active }),
+
   // Session Resume
   getNativeHistory: () => invoke<SavedSession[]>('get_native_history'),
   /** Per-session activity for the contribution heatmap.

--- a/src/server.rs
+++ b/src/server.rs
@@ -793,6 +793,23 @@ fn set_background_mode(hidden: bool) {
         .store(hidden, std::sync::atomic::Ordering::Relaxed);
 }
 
+/// Per-tab visibility flag, flipped by a frontend IntersectionObserver on
+/// each terminal's DOM element. Narrower than `set_background_mode`: a tab
+/// can be inactive this way while the Coffee CLI window itself is still
+/// focused and foreground (e.g. one of several open AI-CLI tabs that isn't
+/// the one currently shown). Widens that single session's emitter coalesce
+/// window instead of parsing/emitting output nobody can see at full cadence.
+/// No-op if the session doesn't exist yet (frontend can fire before the PTY
+/// finishes spawning) or has already been killed.
+#[tauri::command]
+fn set_session_active(session_id: String, active: bool, state: State<'_, AppState>) -> Result<(), String> {
+    let map = state.terminal_session.lock().unwrap();
+    if let Some(session) = map.get(&session_id) {
+        session.is_tab_active.store(active, std::sync::atomic::Ordering::Relaxed);
+    }
+    Ok(())
+}
+
 #[tauri::command]
 fn tier_terminal_kill(session_id: String, state: State<'_, AppState>) -> Result<(), String> {
     let map = state.terminal_session.lock().unwrap();
@@ -2938,6 +2955,7 @@ pub fn start_ui() -> anyhow::Result<()> {
             tier_terminal_kill,
             tier_terminal_resize,
             set_background_mode,
+            set_session_active,
             tier_terminal_resume,
             get_native_history,
             get_message_heatmap,

--- a/src/server.rs
+++ b/src/server.rs
@@ -897,7 +897,44 @@ fn is_system_injected(text: &str) -> bool {
     SYSTEM_INJECTION_TAGS.iter().any(|tag| t.starts_with(tag))
 }
 
-fn parse_agent_jsonl(file_path: &std::path::Path, tool_name: &str) -> Option<SavedSession> {
+/// Claude Code mangles a project's absolute path into its `~/.claude/projects/`
+/// folder name by replacing every non-alphanumeric ASCII character with a
+/// single `-` (verified against live folder names on disk, e.g.
+/// `D:\Coffee-CLI\.claude\worktrees\foo` -> `D--Coffee-CLI--claude-worktrees-foo`).
+/// That mapping is **not reversible**: a literal `-` already inside a path
+/// segment (extremely common — "Coffee-CLI", any kebab-case folder) is
+/// indistinguishable from an encoded separator once collapsed. A previous
+/// version of this function tried to reverse it by splitting the folder name
+/// on "--", which silently produced a plausible-but-wrong path for any
+/// project whose name contained a hyphen — the wrong path would fail the
+/// `path.exists()` guard in `terminal::spawn`, so the CWD override was
+/// silently dropped and `claude --resume <token>` launched from Coffee
+/// CLI's own process directory instead of the session's real project.
+///
+/// Fixed by going the other direction: `~/.claude.json`'s top-level
+/// `projects` object is keyed by the *real*, unmangled absolute path for
+/// every project Claude Code knows about. Forward-encode each candidate
+/// with the same rule and compare — encoding is deterministic and lossless
+/// in this direction, so a match is exact, never a guess.
+fn resolve_claude_cwd_via_registry(home: &std::path::Path, encoded_folder: &str) -> Option<String> {
+    let raw = std::fs::read_to_string(home.join(".claude.json")).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let projects = json.get("projects")?.as_object()?;
+
+    let encode = |real_path: &str| -> String {
+        real_path
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+            .collect()
+    };
+
+    projects
+        .keys()
+        .find(|real_path| encode(real_path) == encoded_folder)
+        .cloned()
+}
+
+fn parse_agent_jsonl(file_path: &std::path::Path, tool_name: &str, home: Option<&std::path::Path>) -> Option<SavedSession> {
     use std::io::BufRead;
     let file = std::fs::File::open(file_path).ok()?;
     let reader = std::io::BufReader::new(file);
@@ -967,21 +1004,20 @@ fn parse_agent_jsonl(file_path: &std::path::Path, tool_name: &str) -> Option<Sav
         }
     }
     
-    // Fallback: If cwd is still empty, derive it from the parent project folder name
-    // e.g., "D--Coffee-Code" -> "D:\Coffee-Code", "C--Users--..." -> "C:\Users\..."
-    if cwd.is_empty() {
-        if let Some(parent) = file_path.parent() {
-            if let Some(folder_name) = parent.file_name().and_then(|n| n.to_str()) {
-                if folder_name.contains("--") {
-                    let mut parts = folder_name.split("--");
-                    if let Some(drive) = parts.next() {
-                        let rest: Vec<&str> = parts.collect();
-                        let decoded_path = if cfg!(target_os = "windows") {
-                            format!("{}:\\{}", drive, rest.join("\\"))
-                        } else {
-                            format!("/{}/{}", drive, rest.join("/"))
-                        };
-                        cwd = decoded_path;
+    // Fallback: JSONL had no embedded cwd (older session, or a line we didn't
+    // recognize). Claude Code's own `~/.claude.json` projects registry is the
+    // only reliable source at that point — see resolve_claude_cwd_via_registry
+    // for why guessing from the folder name is actively wrong, not just
+    // occasionally imprecise. Only Claude has that registry; for any other
+    // tool routed through this generic parser, an unresolved cwd is left
+    // blank rather than guessed, since a wrong-but-existing path silently
+    // sends `--resume` into the wrong project.
+    if cwd.is_empty() && tool_name == "claude" {
+        if let Some(home) = home {
+            if let Some(parent) = file_path.parent() {
+                if let Some(folder_name) = parent.file_name().and_then(|n| n.to_str()) {
+                    if let Some(real_path) = resolve_claude_cwd_via_registry(home, folder_name) {
+                        cwd = real_path;
                     }
                 }
             }
@@ -2189,7 +2225,7 @@ fn load_native_history_blocking() -> Result<Vec<SavedSession>, String> {
             "codex"       => parse_codex_session_jsonl(path),
             "qwen"        => parse_qwen_session_jsonl(path),
             "antigravity" => parse_gemini_session_jsonl(path, &antigravity_project_map),
-            other         => parse_agent_jsonl(path, other),
+            other         => parse_agent_jsonl(path, other, home.as_deref()),
         };
         if let Some(session) = parsed {
             result.push(session);
@@ -2555,6 +2591,22 @@ fn tier_terminal_resume(
         .ok_or_else(|| format!("Unknown tool: {}", tool))?;
     let resume_program = preset.resume_program
         .ok_or_else(|| format!("Tool '{}' does not support resume", tool))?;
+
+    // Claude Code resumes are scoped to the project directory the session
+    // originally ran in (its ~/.claude/projects/<mangled-path>/ folder). If
+    // we couldn't determine that real directory (see
+    // resolve_claude_cwd_via_registry), spawning anyway would silently run
+    // `claude --resume <token>` from Coffee CLI's OWN process directory
+    // instead — indistinguishable from a working resume until the user
+    // notices the wrong project loaded (or Claude fails to find the
+    // session at all). A loud, catchable error here beats a silent
+    // wrong-directory resume, which was reported as "it just crashes/
+    // resumes into a random folder" with no indication why.
+    if tool == "claude" && cwd.trim().is_empty() {
+        return Err(
+            "Could not determine this session's original project folder — refusing to resume into the wrong directory".to_string()
+        );
+    }
 
     // Validate session_token against the tool's token_format.
     // Prevents flag injection: "uuid --dangerously-skip-permissions" would fail this check.
@@ -3136,4 +3188,110 @@ pub fn start_ui() -> anyhow::Result<()> {
         });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod resume_cwd_tests {
+    use super::resolve_claude_cwd_via_registry;
+    use std::io::Write;
+
+    // Isolated per-test home dir under the OS temp dir — avoids clobbering
+    // the real ~/.claude.json and avoids tests racing each other on a
+    // shared path (each test gets a name-derived subfolder).
+    fn temp_home(test_name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("coffee-cli-test-{}", test_name));
+        let _ = std::fs::remove_dir_all(&dir); // clean slate if a prior run left it behind
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_claude_json(home: &std::path::Path, project_paths: &[&str]) {
+        let projects_obj = project_paths
+            .iter()
+            .map(|p| format!("{:?}: {{}}", p)) // {:?} on &str gives a valid escaped JSON string
+            .collect::<Vec<_>>()
+            .join(",");
+        let json = format!(r#"{{"projects": {{{}}}}}"#, projects_obj);
+        let mut f = std::fs::File::create(home.join(".claude.json")).unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+    }
+
+    // Real folder name observed on disk, verified by hand against the
+    // known real path — this is the exact case that motivated the fix
+    // (a project name containing a hyphen, "Coffee-CLI", made the old
+    // split("--") fallback reconstruct a nonexistent path).
+    #[test]
+    fn resolves_real_world_hyphenated_project_path() {
+        let home = temp_home("hyphenated-project");
+        let real_path = r"D:\Coffee-CLI\.claude\worktrees\exciting-swanson-f7e8be";
+        write_claude_json(&home, &[real_path]);
+
+        let resolved = resolve_claude_cwd_via_registry(
+            &home,
+            "D--Coffee-CLI--claude-worktrees-exciting-swanson-f7e8be",
+        );
+
+        assert_eq!(resolved, Some(real_path.to_string()));
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn resolves_second_real_world_project_path() {
+        let home = temp_home("echobird-project");
+        let real_path = r"E:\EchoBird";
+        write_claude_json(&home, &[real_path]);
+
+        let resolved = resolve_claude_cwd_via_registry(&home, "E--EchoBird");
+
+        assert_eq!(resolved, Some(real_path.to_string()));
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn returns_none_when_no_project_matches_the_encoded_folder() {
+        let home = temp_home("no-match");
+        write_claude_json(&home, &[r"D:\some\other\project"]);
+
+        let resolved = resolve_claude_cwd_via_registry(&home, "D--Coffee-CLI--claude-worktrees-foo");
+
+        assert_eq!(resolved, None);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn returns_none_when_claude_json_is_missing() {
+        let home = temp_home("missing-config");
+        // Deliberately don't write .claude.json.
+
+        let resolved = resolve_claude_cwd_via_registry(&home, "D--anything");
+
+        assert_eq!(resolved, None);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    // The old split("--") fallback got this case actively wrong: it would
+    // reconstruct "D:\Coffee-CLI\claude-worktrees-exciting-swanson-f7e8be"
+    // (missing the leading dot before "claude", "worktrees" and
+    // "exciting-swanson-f7e8be" wrongly merged) instead of the real path.
+    // The registry lookup sidesteps that ambiguity entirely by encoding
+    // forward from the known-real path rather than decoding backward from
+    // the mangled folder name — this test locks in that it does NOT fall
+    // back to producing the old wrong guess when the registry has no match.
+    #[test]
+    fn does_not_reconstruct_the_old_broken_guess_when_unresolvable() {
+        let home = temp_home("no-registry-entry-for-hyphenated-project");
+        write_claude_json(&home, &[]); // registry present but empty — no candidates at all
+
+        let resolved = resolve_claude_cwd_via_registry(
+            &home,
+            "D--Coffee-CLI--claude-worktrees-exciting-swanson-f7e8be",
+        );
+
+        assert_ne!(
+            resolved,
+            Some(r"D:\Coffee-CLI\claude-worktrees-exciting-swanson-f7e8be".to_string())
+        );
+        assert_eq!(resolved, None);
+        let _ = std::fs::remove_dir_all(&home);
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -897,6 +897,60 @@ fn is_system_injected(text: &str) -> bool {
     SYSTEM_INJECTION_TAGS.iter().any(|tag| t.starts_with(tag))
 }
 
+/// Resolve a session's real project root from its recorded cwd.
+///
+/// A session run inside an ephemeral worktree (`<project>/.claude/worktrees/<x>`,
+/// created by the harness for each Claude dev session) records that worktree as
+/// its cwd. Resuming there is wrong — the worktree is scratch space that may be
+/// on a stale branch or already gone; the user wants to continue in the actual
+/// project. `<tool> --resume <token>` finds the session by its global id
+/// regardless of cwd, so running from the project root both recovers the
+/// conversation and lands in the right place (verified live).
+///
+/// Rule: match the `.claude/worktrees` segment specifically and strip back to
+/// the segment before `.claude`. That layout is the harness's own (verified on
+/// disk — `git worktree list` shows every worktree at `<project>/.claude/
+/// worktrees/<name>`), and it is the ONLY dot-directory that is ever a real
+/// working cwd: a `.git/worktrees/<x>` is git's internal metadata (never a
+/// working dir), and an ordinary hidden dir (`~/.config/nvim`, `~/.dotfiles`)
+/// has no `worktrees` child. Anchoring on `.claude/worktrees` therefore:
+///   • fixes the worktree case on every OS (both `\` and `/` separators);
+///   • never over-collapses a legitimate hidden-dir cwd (important on
+///     Linux/macOS where editing dotfiles with an agent is a real workflow);
+///   • covers any tool Coffee CLI launched inside such a worktree (they all
+///     record the same `.claude/worktrees` path), without a per-tool branch.
+/// Any cwd without that exact segment (a normal project dir, a real subdir, a
+/// plain non-hidden `worktrees/` folder) is returned unchanged. Guaranteed to
+/// never return an empty string when given a non-empty one.
+fn project_root_from_cwd(cwd: &str) -> String {
+    let is_sep = |b: u8| b == b'\\' || b == b'/';
+    let bytes = cwd.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if is_sep(bytes[i]) {
+            // Component immediately after this separator.
+            let start = i + 1;
+            let mut j = start;
+            while j < bytes.len() && !is_sep(bytes[j]) {
+                j += 1;
+            }
+            // Must be `.claude`, and its next component must be `worktrees`.
+            // `i > 0` keeps a non-empty input from ever collapsing to "".
+            if i > 0 && &cwd[start..j] == ".claude" && j < bytes.len() {
+                let mut k = j + 1;
+                while k < bytes.len() && !is_sep(bytes[k]) {
+                    k += 1;
+                }
+                if &cwd[j + 1..k] == "worktrees" {
+                    return cwd[..i].to_string();
+                }
+            }
+        }
+        i += 1;
+    }
+    cwd.to_string()
+}
+
 /// Claude Code mangles a project's absolute path into its `~/.claude/projects/`
 /// folder name by replacing every non-alphanumeric ASCII character with a
 /// single `-` (verified against live folder names on disk, e.g.
@@ -913,28 +967,51 @@ fn is_system_injected(text: &str) -> bool {
 ///
 /// Fixed by going the other direction: `~/.claude.json`'s top-level
 /// `projects` object is keyed by the *real*, unmangled absolute path for
-/// every project Claude Code knows about. Forward-encode each candidate
-/// with the same rule and compare — encoding is deterministic and lossless
-/// in this direction, so a match is exact, never a guess.
-fn resolve_claude_cwd_via_registry(home: &std::path::Path, encoded_folder: &str) -> Option<String> {
-    let raw = std::fs::read_to_string(home.join(".claude.json")).ok()?;
-    let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
-    let projects = json.get("projects")?.as_object()?;
-
-    let encode = |real_path: &str| -> String {
-        real_path
-            .chars()
-            .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-            .collect()
+/// every project Claude Code knows about. Forward-encode each key with the
+/// same rule — encoding is deterministic and lossless in this direction, so a
+/// match is exact, never a guess.
+///
+/// Built ONCE per history scan and passed into `parse_agent_jsonl` (mirroring
+/// `antigravity_project_map`), rather than re-reading + re-parsing this
+/// (often 100 KB+) file per candidate session.
+fn load_claude_project_map(home: &std::path::Path) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    let path = home.join(".claude.json");
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(r) => r,
+        // Missing file is the normal "no Claude yet" case — silent. A present
+        // file we can't read is worth a breadcrumb (a resume that later refuses
+        // has a diagnosable root cause instead of a silent empty map).
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return map,
+        Err(e) => {
+            eprintln!("[history] could not read {}: {e}", path.display());
+            return map;
+        }
     };
-
-    projects
-        .keys()
-        .find(|real_path| encode(real_path) == encoded_folder)
-        .cloned()
+    let json: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[history] {} is not valid JSON: {e}", path.display());
+            return map;
+        }
+    };
+    if let Some(projects) = json.get("projects").and_then(|v| v.as_object()) {
+        for real_path in projects.keys() {
+            let encoded: String = real_path
+                .chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+                .collect();
+            map.insert(encoded, real_path.clone());
+        }
+    }
+    map
 }
 
-fn parse_agent_jsonl(file_path: &std::path::Path, tool_name: &str, home: Option<&std::path::Path>) -> Option<SavedSession> {
+fn parse_agent_jsonl(
+    file_path: &std::path::Path,
+    tool_name: &str,
+    claude_projects: &std::collections::HashMap<String, String>,
+) -> Option<SavedSession> {
     use std::io::BufRead;
     let file = std::fs::File::open(file_path).ok()?;
     let reader = std::io::BufReader::new(file);
@@ -1006,21 +1083,19 @@ fn parse_agent_jsonl(file_path: &std::path::Path, tool_name: &str, home: Option<
     
     // Fallback: JSONL had no embedded cwd (older session, or a line we didn't
     // recognize). Claude Code's own `~/.claude.json` projects registry is the
-    // only reliable source at that point — see resolve_claude_cwd_via_registry
-    // for why guessing from the folder name is actively wrong, not just
-    // occasionally imprecise. Only Claude has that registry; for any other
-    // tool routed through this generic parser, an unresolved cwd is left
-    // blank rather than guessed, since a wrong-but-existing path silently
-    // sends `--resume` into the wrong project.
+    // only reliable source at that point — see load_claude_project_map for why
+    // guessing from the folder name is actively wrong, not just imprecise. Only
+    // Claude has that registry; any other tool routed through this generic
+    // parser keeps a blank cwd rather than a guess (a wrong-but-existing path
+    // would silently send `--resume` into the wrong project).
     if cwd.is_empty() && tool_name == "claude" {
-        if let Some(home) = home {
-            if let Some(parent) = file_path.parent() {
-                if let Some(folder_name) = parent.file_name().and_then(|n| n.to_str()) {
-                    if let Some(real_path) = resolve_claude_cwd_via_registry(home, folder_name) {
-                        cwd = real_path;
-                    }
-                }
-            }
+        if let Some(real_path) = file_path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .and_then(|folder| claude_projects.get(folder))
+        {
+            cwd = real_path.clone();
         }
     }
     let turn_count = if total_messages > 0 { std::cmp::max(1, (total_messages + 1) / 2) } else { 0 };
@@ -2219,13 +2294,21 @@ fn load_native_history_blocking() -> Result<Vec<SavedSession>, String> {
         std::collections::HashMap::new()
     };
 
+    // Same treatment for Claude's encoded-folder → real-cwd registry: read and
+    // encode `~/.claude.json` ONCE (not per empty-cwd session), and only if
+    // there are Claude candidates that might need the fallback at all.
+    let claude_project_map = match (&home, file_candidates.iter().any(|(_, _, t)| *t == "claude")) {
+        (Some(h), true) => load_claude_project_map(h),
+        _ => std::collections::HashMap::new(),
+    };
+
     for (_, path, tool) in &file_candidates {
         let parsed = match *tool {
             "hermes"      => parse_hermes_json(path),
             "codex"       => parse_codex_session_jsonl(path),
             "qwen"        => parse_qwen_session_jsonl(path),
             "antigravity" => parse_gemini_session_jsonl(path, &antigravity_project_map),
-            other         => parse_agent_jsonl(path, other, home.as_deref()),
+            other         => parse_agent_jsonl(path, other, &claude_project_map),
         };
         if let Some(session) = parsed {
             result.push(session);
@@ -2258,6 +2341,18 @@ fn load_native_history_blocking() -> Result<Vec<SavedSession>, String> {
     if let Some(home) = home.as_ref() {
         if let Some(db) = mimocode_db(home) {
             find_drizzle_sessions_sqlite(&db, "mimocode", "MiMo Code Session", &mut result);
+        }
+    }
+
+    // Collapse any Claude-worktree cwd to its project root, for every tool's
+    // sessions (a session launched from <project>/.claude/worktrees/<x> should
+    // resume in <project>, not the ephemeral worktree). No-op for normal dirs;
+    // project_root_from_cwd never shrinks a non-empty path to empty. Single
+    // point so the folder shown in the UI and the folder used for resume can
+    // never disagree.
+    for s in result.iter_mut() {
+        if !s.cwd.is_empty() {
+            s.cwd = project_root_from_cwd(&s.cwd);
         }
     }
 
@@ -2592,20 +2687,25 @@ fn tier_terminal_resume(
     let resume_program = preset.resume_program
         .ok_or_else(|| format!("Tool '{}' does not support resume", tool))?;
 
-    // Claude Code resumes are scoped to the project directory the session
-    // originally ran in (its ~/.claude/projects/<mangled-path>/ folder). If
-    // we couldn't determine that real directory (see
-    // resolve_claude_cwd_via_registry), spawning anyway would silently run
-    // `claude --resume <token>` from Coffee CLI's OWN process directory
-    // instead — indistinguishable from a working resume until the user
-    // notices the wrong project loaded (or Claude fails to find the
-    // session at all). A loud, catchable error here beats a silent
-    // wrong-directory resume, which was reported as "it just crashes/
-    // resumes into a random folder" with no indication why.
-    if tool == "claude" && cwd.trim().is_empty() {
-        return Err(
-            "Could not determine this session's original project folder — refusing to resume into the wrong directory".to_string()
-        );
+    // A resume must land in the session's real project directory. If we can't —
+    // the cwd is empty (never recorded, e.g. legacy Hermes JSON, or an
+    // unresolved Claude session), OR it points at a folder that no longer
+    // exists (project moved/deleted, disconnected network drive) — then
+    // spawning anyway would silently inherit Coffee CLI's OWN process directory,
+    // because terminal::spawn drops a non-existent cwd via its `path.exists()`
+    // guard. That is the "it just resumes into a random folder" failure with no
+    // indication why. Refuse loudly instead (tool-agnostic: every tool's
+    // `--resume <token>` finds the session by id regardless of cwd, so the user
+    // can still resume manually from the right place once told which folder is
+    // missing). Checking existence, not just emptiness, closes the case where a
+    // worktree cwd was collapsed to a project root that has since been removed.
+    let resume_dir = cwd.trim();
+    if !std::path::Path::new(resume_dir).is_dir() {
+        return Err(if resume_dir.is_empty() {
+            "Could not determine this session's project folder — refusing to resume into the wrong directory".to_string()
+        } else {
+            format!("This session's project folder no longer exists ({resume_dir}) — refusing to resume into the wrong directory")
+        });
     }
 
     // Validate session_token against the tool's token_format.
@@ -3192,8 +3292,87 @@ pub fn start_ui() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod resume_cwd_tests {
-    use super::resolve_claude_cwd_via_registry;
+    use super::{load_claude_project_map, project_root_from_cwd};
     use std::io::Write;
+
+    // The exact path that was landing wrong in the wild: a Claude session run
+    // inside a worktree recorded the worktree as its cwd, so resume cd'd into
+    // the ephemeral worktree instead of the project root.
+    #[test]
+    fn strips_windows_worktree_cwd_to_project_root() {
+        assert_eq!(
+            project_root_from_cwd(r"D:\Coffee-CLI\.claude\worktrees\intelligent-heyrovsky-b3d421"),
+            r"D:\Coffee-CLI"
+        );
+    }
+
+    #[test]
+    fn strips_unix_worktree_cwd_to_project_root() {
+        assert_eq!(
+            project_root_from_cwd("/home/eben/coffee-cli/.claude/worktrees/foo"),
+            "/home/eben/coffee-cli"
+        );
+    }
+
+    #[test]
+    fn leaves_a_plain_project_dir_unchanged() {
+        assert_eq!(project_root_from_cwd(r"D:\Coffee-CLI"), r"D:\Coffee-CLI");
+        assert_eq!(project_root_from_cwd("/home/eben/coffee-cli"), "/home/eben/coffee-cli");
+    }
+
+    #[test]
+    fn leaves_a_real_subdir_unchanged() {
+        // A genuine working subdir must NOT be collapsed — only worktrees.
+        assert_eq!(project_root_from_cwd(r"D:\Coffee-CLI\src\ui"), r"D:\Coffee-CLI\src\ui");
+    }
+
+    #[test]
+    fn strips_only_dot_claude_worktrees_not_other_dot_dir_worktrees() {
+        // `.claude/worktrees` is the harness's real worktree layout, so it
+        // strips. `.git/worktrees` is git's INTERNAL metadata (never a working
+        // cwd), so anchoring on `.claude` specifically leaves it — and any
+        // other `.<dir>/worktrees` — untouched, avoiding a bogus over-collapse.
+        assert_eq!(project_root_from_cwd(r"D:\proj\.git\worktrees\x"), r"D:\proj\.git\worktrees\x");
+        assert_eq!(project_root_from_cwd("/home/e/proj/.jj/worktrees/y"), "/home/e/proj/.jj/worktrees/y");
+    }
+
+    #[test]
+    fn does_not_touch_an_ordinary_hidden_dir_without_worktrees() {
+        // The Linux/macOS safety case: editing dotfiles with an agent runs the
+        // session INSIDE a hidden dir; that cwd must survive intact.
+        assert_eq!(project_root_from_cwd("/home/eben/.config/nvim"), "/home/eben/.config/nvim");
+        assert_eq!(project_root_from_cwd("/home/eben/.dotfiles"), "/home/eben/.dotfiles");
+        assert_eq!(project_root_from_cwd(r"D:\proj\.vscode"), r"D:\proj\.vscode");
+        // `.claude` itself, without a worktrees child, is a real (if unusual) dir.
+        assert_eq!(project_root_from_cwd(r"D:\Coffee-CLI\.claude"), r"D:\Coffee-CLI\.claude");
+        assert_eq!(project_root_from_cwd(r"D:\Coffee-CLI\.claude\settings"), r"D:\Coffee-CLI\.claude\settings");
+    }
+
+    #[test]
+    fn requires_worktrees_to_be_a_whole_next_component() {
+        // A plain, non-hidden `worktrees/` folder is a legitimate project subdir.
+        assert_eq!(project_root_from_cwd(r"D:\proj\worktrees\x"), r"D:\proj\worktrees\x");
+        // `worktrees` must be a WHOLE next component, not a prefix.
+        assert_eq!(
+            project_root_from_cwd(r"D:\proj\.claude\worktrees-archive\x"),
+            r"D:\proj\.claude\worktrees-archive\x"
+        );
+    }
+
+    #[test]
+    fn handles_mixed_separators_and_non_ascii() {
+        // Windows sometimes emits mixed separators; a Chinese project name must
+        // not panic the byte-slice (all slice indices land on ASCII separators).
+        assert_eq!(project_root_from_cwd(r"D:/Coffee-CLI\.claude/worktrees\x"), r"D:/Coffee-CLI");
+        assert_eq!(project_root_from_cwd(r"D:\项目名\.claude\worktrees\x"), r"D:\项目名");
+    }
+
+    #[test]
+    fn does_not_split_on_a_dot_inside_a_component() {
+        // The dot must open a `.claude` component; a dot mid-name never matches.
+        assert_eq!(project_root_from_cwd(r"D:\proj\my.claude\worktrees\x"), r"D:\proj\my.claude\worktrees\x");
+        assert_eq!(project_root_from_cwd(r"D:\tools\v1.2\bin"), r"D:\tools\v1.2\bin");
+    }
 
     // Isolated per-test home dir under the OS temp dir — avoids clobbering
     // the real ~/.claude.json and avoids tests racing each other on a
@@ -3216,82 +3395,70 @@ mod resume_cwd_tests {
         f.write_all(json.as_bytes()).unwrap();
     }
 
-    // Real folder name observed on disk, verified by hand against the
-    // known real path — this is the exact case that motivated the fix
-    // (a project name containing a hyphen, "Coffee-CLI", made the old
-    // split("--") fallback reconstruct a nonexistent path).
+    // Real folder name observed on disk, verified by hand against the known
+    // real path — the exact case that motivated the fix (a project name
+    // containing a hyphen, "Coffee-CLI", made the old split("--") fallback
+    // reconstruct a nonexistent path). load_claude_project_map forward-encodes
+    // the real key so the mangled folder name maps back exactly.
     #[test]
-    fn resolves_real_world_hyphenated_project_path() {
+    fn map_resolves_real_world_hyphenated_project_path() {
         let home = temp_home("hyphenated-project");
         let real_path = r"D:\Coffee-CLI\.claude\worktrees\exciting-swanson-f7e8be";
         write_claude_json(&home, &[real_path]);
 
-        let resolved = resolve_claude_cwd_via_registry(
-            &home,
-            "D--Coffee-CLI--claude-worktrees-exciting-swanson-f7e8be",
-        );
+        let map = load_claude_project_map(&home);
 
-        assert_eq!(resolved, Some(real_path.to_string()));
+        assert_eq!(
+            map.get("D--Coffee-CLI--claude-worktrees-exciting-swanson-f7e8be").map(String::as_str),
+            Some(real_path)
+        );
         let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]
-    fn resolves_second_real_world_project_path() {
+    fn map_resolves_second_real_world_project_path() {
         let home = temp_home("echobird-project");
         let real_path = r"E:\EchoBird";
         write_claude_json(&home, &[real_path]);
 
-        let resolved = resolve_claude_cwd_via_registry(&home, "E--EchoBird");
+        let map = load_claude_project_map(&home);
 
-        assert_eq!(resolved, Some(real_path.to_string()));
+        assert_eq!(map.get("E--EchoBird").map(String::as_str), Some(real_path));
         let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]
-    fn returns_none_when_no_project_matches_the_encoded_folder() {
+    fn map_has_no_entry_for_an_unregistered_folder() {
         let home = temp_home("no-match");
         write_claude_json(&home, &[r"D:\some\other\project"]);
 
-        let resolved = resolve_claude_cwd_via_registry(&home, "D--Coffee-CLI--claude-worktrees-foo");
+        let map = load_claude_project_map(&home);
 
-        assert_eq!(resolved, None);
+        assert_eq!(map.get("D--Coffee-CLI--claude-worktrees-foo"), None);
         let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]
-    fn returns_none_when_claude_json_is_missing() {
+    fn map_is_empty_when_claude_json_is_missing() {
         let home = temp_home("missing-config");
         // Deliberately don't write .claude.json.
-
-        let resolved = resolve_claude_cwd_via_registry(&home, "D--anything");
-
-        assert_eq!(resolved, None);
+        assert!(load_claude_project_map(&home).is_empty());
         let _ = std::fs::remove_dir_all(&home);
     }
 
-    // The old split("--") fallback got this case actively wrong: it would
-    // reconstruct "D:\Coffee-CLI\claude-worktrees-exciting-swanson-f7e8be"
-    // (missing the leading dot before "claude", "worktrees" and
-    // "exciting-swanson-f7e8be" wrongly merged) instead of the real path.
-    // The registry lookup sidesteps that ambiguity entirely by encoding
-    // forward from the known-real path rather than decoding backward from
-    // the mangled folder name — this test locks in that it does NOT fall
-    // back to producing the old wrong guess when the registry has no match.
     #[test]
-    fn does_not_reconstruct_the_old_broken_guess_when_unresolvable() {
-        let home = temp_home("no-registry-entry-for-hyphenated-project");
-        write_claude_json(&home, &[]); // registry present but empty — no candidates at all
+    fn map_is_empty_and_does_not_panic_on_malformed_json() {
+        // A truncated/corrupt ~/.claude.json (a real post-crashed-write state)
+        // must degrade to an empty map (and an eprintln breadcrumb), never panic
+        // or reconstruct the old broken split("--") guess.
+        let home = temp_home("malformed-config");
+        let mut f = std::fs::File::create(home.join(".claude.json")).unwrap();
+        f.write_all(br#"{"projects": {"D:\Coffee-CLI": {"#).unwrap(); // truncated
+        drop(f);
 
-        let resolved = resolve_claude_cwd_via_registry(
-            &home,
-            "D--Coffee-CLI--claude-worktrees-exciting-swanson-f7e8be",
-        );
+        let map = load_claude_project_map(&home);
 
-        assert_ne!(
-            resolved,
-            Some(r"D:\Coffee-CLI\claude-worktrees-exciting-swanson-f7e8be".to_string())
-        );
-        assert_eq!(resolved, None);
+        assert!(map.is_empty());
         let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -430,6 +430,15 @@ pub struct TerminalSession {
     pub(crate) _master: Arc<Mutex<Option<Box<dyn portable_pty::MasterPty + Send>>>>,
     /// Shared activity state for status detection.
     pub activity: Arc<Mutex<SessionActivity>>,
+    /// True when this session's terminal is actually on-screen — its tab is
+    /// the active center-panel tab, or (for split panes) its parent tab is
+    /// active. Flipped by `set_session_active`, called from a frontend
+    /// IntersectionObserver on the terminal's DOM element. This is narrower
+    /// than `BACKGROUND_MODE`: a tab can be backgrounded this way while the
+    /// Coffee CLI window itself is still focused and foreground. Defaults
+    /// true so a session runs at full cadence until the frontend's first
+    /// visibility report lands.
+    pub is_tab_active: Arc<AtomicBool>,
     /// Ring buffer of recent base64-encoded output chunks. Originally
     /// populated for DetachedTerminal's history replay (retired 2026-04)
     /// and the MCP `read_pane` tool (also archived). Currently referenced
@@ -859,6 +868,9 @@ pub fn spawn(
     // emitter lock. Set to false exactly once, from the emitter cleanup path.
     let alive_flag: Arc<AtomicBool> = Arc::new(AtomicBool::new(true));
 
+    // See `TerminalSession::is_tab_active` doc comment — defaults active.
+    let is_tab_active: Arc<AtomicBool> = Arc::new(AtomicBool::new(true));
+
     // Store session (with shared writer reference + master kept alive + activity)
     let output_buffer: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
     {
@@ -875,6 +887,7 @@ pub fn spawn(
             _master: master_clone,
             activity: activity_clone,
             output_buffer: buffer_clone,
+            is_tab_active: is_tab_active.clone(),
         });
     }
 
@@ -914,6 +927,15 @@ pub fn spawn(
         loop {
             // 500ms when foreground, 5s when window is hidden — agent status
             // updates can lag a few seconds when the user isn't looking.
+            //
+            // Deliberately does NOT also check `is_tab_active` the way the
+            // emitter below does (see that flush_interval for the per-tab
+            // signal). The working/idle dot is read from the tab strip even
+            // for a tab that isn't the active one — throttling detection for
+            // a backgrounded-but-still-visible-in-the-strip tab would make
+            // that indicator lag exactly when it's most useful (watching a
+            // background AI-CLI tab finish). Only whole-window hidden
+            // (nothing on screen to read) earns the slower cadence here.
             let interval_ms = if BACKGROUND_MODE.load(Ordering::Relaxed) { 5000 } else { 500 };
             std::thread::sleep(std::time::Duration::from_millis(interval_ms));
             // Cheap atomic check — no mutex contention with the emitter.
@@ -1067,6 +1089,7 @@ pub fn spawn(
     let session_id_out = session_id.clone();
     let activity_for_emitter = activity.clone();
     let output_buffer_for_emitter = output_buffer.clone();
+    let is_active_for_emitter = is_tab_active.clone();
 
     std::thread::spawn(move || {
         use std::sync::mpsc::RecvTimeoutError;
@@ -1074,13 +1097,18 @@ pub fn spawn(
 
         // 8 ms is below human-perceptible latency (~16 ms frame) but large
         // enough to collapse a typical AI-CLI token-stream burst (hundreds of
-        // small writes) into a single emit. When the window is hidden, widen
-        // to 200 ms so a backgrounded Coffee CLI window stops generating
-        // 125 IPC events / sec / session for output the user can't see.
+        // small writes) into a single emit. Widen to 200 ms whenever nobody
+        // can see this output right now — either the whole Coffee CLI window
+        // is hidden (BACKGROUND_MODE), or this session's own tab isn't the
+        // one on screen (is_tab_active, e.g. a background tab while the
+        // window itself stays focused). Both cases stop paying full 8 ms
+        // parse+emit cadence for a stream nobody is watching.
         const FLUSH_INTERVAL_FG: StdDuration = StdDuration::from_millis(8);
         const FLUSH_INTERVAL_BG: StdDuration = StdDuration::from_millis(200);
         let flush_interval = || {
-            if BACKGROUND_MODE.load(Ordering::Relaxed) {
+            if BACKGROUND_MODE.load(Ordering::Relaxed)
+                || !is_active_for_emitter.load(Ordering::Relaxed)
+            {
                 FLUSH_INTERVAL_BG
             } else {
                 FLUSH_INTERVAL_FG

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Coffee CLI",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "identifier": "com.coffeecli.desktop",
   "build": {
     "frontendDist": "./src-ui/dist",


### PR DESCRIPTION
Release 2.9.7 — bundles the worktree work on top of main (v2.9.6).

**Changes**
- feat(titlebar): tool tabs moved onto the drag bar (Windows-Terminal style); active tab seams into the content, one continuous frame with the side rails
- fix(terminal): Linux CJK IME punctuation duplication (WebKitGTK) — app-layer fix on stable xterm 6.0.0, replaces the Linux-only 6.1.0-beta stopgap
- fix(history): "Continue this session" now returns to the session's real project dir (not the worktree)
- fix(terminal): stop writing our own exit-code banner into the scrollback
- feat(settings): BUG / 建议 feedback links section
- perf(terminal): cap WebGL contexts + throttle backgrounded tabs
- i18n: font-picker labels + web hero across remaining locales

`chore: release 2.9.7` bumps Cargo.toml / Cargo.lock / tauri.conf.json and fills the 5-language release-notes template. `version.json` is intentionally untouched — CI bumps it on Publish.

**After merge:** tag `v2.9.7` on main → release.yml builds the draft.