### PR TITLE
feat(launchpad): hover-reveal delete on recent-folder dropdown

### DIFF
--- a/src-ui/src/components/center/CenterPanel.css
+++ b/src-ui/src/components/center/CenterPanel.css
@@ -493,6 +493,27 @@
 }
 .folder-menu-sep { height: 1px; background: var(--border); margin: 4px 2px; }
 .folder-menu-open .folder-menu-name { font-weight: 500; color: var(--text-2); }
+/* Per-row delete affordance: hidden at rest, muted on row hover, red on its own hover. */
+.folder-menu-del {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  color: var(--text-3, var(--text-2));
+  opacity: 0;
+  transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease;
+}
+.folder-menu-item:hover .folder-menu-del { opacity: 0.55; }
+.folder-menu-item:hover .folder-menu-del:hover {
+  opacity: 1;
+  color: var(--red);
+  background: color-mix(in srgb, var(--red) 15%, transparent);
+}
+.folder-menu-item .folder-menu-del svg { opacity: 1; color: inherit; }
 
 .launchpad-folder-btn svg {
   width: 28px;

--- a/src-ui/src/components/center/CenterPanel.tsx
+++ b/src-ui/src/components/center/CenterPanel.tsx
@@ -16,12 +16,13 @@ import { useAppState, type ToolType } from '../../store/app-state';
 // Clicking a recent launches THIS card's tool in that folder; the card body
 // click is unchanged (old flow). Portal-rendered with outside-click / Esc to
 // close — same pattern as the terminal context menu.
-function RecentFolderMenu({ x, y, recent, openLabel, onPick, onOpenNew, onClose }: {
+function RecentFolderMenu({ x, y, recent, openLabel, onPick, onRemove, onOpenNew, onClose }: {
   x: number;
   y: number;
   recent: string[];
   openLabel: string;
   onPick: (folder: string) => void;
+  onRemove: (folder: string) => void;
   onOpenNew: () => void;
   onClose: () => void;
 }) {
@@ -53,6 +54,19 @@ function RecentFolderMenu({ x, y, recent, openLabel, onPick, onOpenNew, onClose 
       <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
     </svg>
   );
+  const XGlyph = (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 6 6 18M6 6l12 12" />
+    </svg>
+  );
+  // Same folder body as FolderGlyph + a plus, so "open new" reads as the same
+  // family as the recents above it, just clearly the "add another" action.
+  const FolderPlusGlyph = (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+      <path d="M12 11v6M9 14h6" />
+    </svg>
+  );
 
   return createPortal(
     <div ref={ref} className="folder-menu" style={{ left, top }}>
@@ -63,12 +77,20 @@ function RecentFolderMenu({ x, y, recent, openLabel, onPick, onOpenNew, onClose 
             {FolderGlyph}
             <span className="folder-menu-name">{name}</span>
             {parent && <span className="folder-menu-path">{parent}</span>}
+            <span
+              className="folder-menu-del"
+              role="button"
+              aria-label={`Remove ${name}`}
+              onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); onRemove(f); }}
+            >
+              {XGlyph}
+            </span>
           </button>
         );
       })}
       {recent.length > 0 && <div className="folder-menu-sep" />}
       <button className="folder-menu-item folder-menu-open" onMouseDown={(e) => { e.preventDefault(); onOpenNew(); }}>
-        {FolderGlyph}
+        {FolderPlusGlyph}
         <span className="folder-menu-name">{openLabel}</span>
       </button>
     </div>,
@@ -660,6 +682,13 @@ export function CenterPanel() {
   const pushRecentFolder = (folder: string) => {
     setRecentFolders(prev => {
       const next = [folder, ...prev.filter(f => f !== folder)].slice(0, 8);
+      try { localStorage.setItem('coffee:recent-folders', JSON.stringify(next)); } catch {}
+      return next;
+    });
+  };
+  const removeRecentFolder = (folder: string) => {
+    setRecentFolders(prev => {
+      const next = prev.filter(f => f !== folder);
       try { localStorage.setItem('coffee:recent-folders', JSON.stringify(next)); } catch {}
       return next;
     });
@@ -1809,6 +1838,7 @@ export function CenterPanel() {
           recent={recentFolders}
           openLabel={t('launchpad.open_folder' as any) || 'Open folder…'}
           onPick={(f) => { selectTool(folderMenu.tool, undefined, f); setFolderMenu(null); }}
+          onRemove={(f) => removeRecentFolder(f)}
           onOpenNew={() => { const tk = folderMenu.tool; setFolderMenu(null); handlePickFolder(tk); }}
           onClose={() => setFolderMenu(null)}
         />


### PR DESCRIPTION
## 做了什么

工具卡「选择文件夹」下拉里的每条最近记录,现在支持**悬停显隐的删除**——用户可以快速清掉点错的/临时的历史项。

- **三态**:静止隐藏 → 行 hover 时右侧浮现灰 X(`opacity:0.55`)→ X 自身 hover 转红 + 淡红圆底(`color-mix` 叠主题 `--red`)
- **点 X 只删该条**(从 `localStorage['coffee:recent-folders']` filter 移除),**绝不打开文件夹**——`onMouseDown` 里 `stopPropagation` 挡住行的启动;菜单保持打开,可连删
- 删空优雅降级为只剩「打开文件夹」
- 顺带:「打开文件夹」换成 `folder-plus` 图标,和上面普通文件夹的历史项区分开
- 纯图标按钮无可见文字,可访问名用硬编码 `aria-label`,不占 i18n

## 验证

- `tsc -b` 通过(worktree 经 junction 主仓 node_modules)
- 真实 dev server 浏览器实测(eval 端到端):菜单渲染 3 个删除按钮就位;删除 3→2 只移除目标行并持久化;删除时 `xterm=0` 证明未误触发启动;菜单不关

## 影响面

仅 `CenterPanel` 的 `RecentFolderMenu` + 其 CSS,+53/-2,无后端/无 i18n 改动。