### PR TITLE
fix(terminal): 修复拖选中断、选中高亮不可见、裸终端光标隐藏

### DIFF
--- a/src-ui/src/components/center/TierTerminal.css
+++ b/src-ui/src/components/center/TierTerminal.css
@@ -137,9 +137,11 @@
     opacity: 0.9;
 }
 
-/* Completely hide native xterm cursor */
-.tier-xterm .xterm-cursor,
-.tier-xterm .xterm-cursor-layer {
+/* Completely hide native xterm cursor — except in raw-shell tabs (local
+   terminal / remote SSH), where no TUI paints its own caret and the xterm
+   cursor is the only input-position indicator the user has (issue #95). */
+.tier-xterm:not(.raw-shell) .xterm-cursor,
+.tier-xterm:not(.raw-shell) .xterm-cursor-layer {
     display: none !important;
     opacity: 0 !important;
 }

--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -121,22 +121,27 @@ function normalizePasteNewlines(text: string): string {
 // Derive a slightly-darker, alpha-blended selection background from the
 // scheme's fg (or the warm coffee fallback). Multiplying RGB by 0.8 first
 // gives the "比主题色深点" feel before xterm composites it over the bg.
+// Alpha stays deliberately high: at 0.3-0.4 the highlight was effectively
+// invisible against dark backgrounds, so users concluded drag selection
+// was broken when it was actually working (issue #92).
 function deriveSelectionBg(hex: string, isDark: boolean): string {
   const m = /^#([0-9a-f]{6})$/i.exec(hex);
-  if (!m) return isDark ? 'rgba(196,149,106,0.3)' : 'rgba(196,149,106,0.25)';
+  if (!m) return isDark ? 'rgba(196,149,106,0.55)' : 'rgba(196,149,106,0.45)';
   const n = parseInt(m[1], 16);
   const r = Math.round(((n >> 16) & 0xff) * 0.8);
   const g = Math.round(((n >> 8) & 0xff) * 0.8);
   const b = Math.round((n & 0xff) * 0.8);
-  return `rgba(${r},${g},${b},${isDark ? 0.4 : 0.3})`;
+  return `rgba(${r},${g},${b},${isDark ? 0.55 : 0.45})`;
 }
 
-// xterm's caret was a leftover from raw-shell mode (terminal / remote) — every
-// other surface the user touches (each AI agent's input box, the Compose
-// textarea) paints its own caret, so xterm's was either redundant or a
-// stranded artifact. Always paint the cursor in the background color so the
-// WebGL renderer effectively erases it; the DOM renderer is also covered by
-// `.xterm-cursor { display: none }` in TierTerminal.css.
+// In AI-agent tabs the upstream TUI (each agent's input box, the Compose
+// textarea) paints its own caret, so xterm's cursor is either redundant or a
+// stranded artifact — paint it in the background color so the WebGL renderer
+// effectively erases it (the DOM renderer is covered by
+// `.xterm-cursor { display: none }` in TierTerminal.css).
+// Raw-shell tabs (local terminal / remote SSH) are the exception: no TUI
+// draws a caret there, so the xterm cursor is the only input-position
+// indicator — keep it visible with the foreground color (issue #95).
 // Build the xterm fontFamily stack. `userFont` (from Settings) is prepended
 // so it wins for the glyphs it has; the bundled CascadiaMono + Nerd Fonts +
 // platform monospace faces follow, and the CJK cascade backstops Chinese/
@@ -157,7 +162,7 @@ export function buildFontFamily(userFont?: string): string {
   return userFont ? `"${userFont}", ${base}` : base;
 }
 
-function buildXtermTheme(themeName: string, hasBg: boolean | undefined, schemeId?: string) {
+function buildXtermTheme(themeName: string, hasBg: boolean | undefined, schemeId?: string, rawShell = false) {
   const isDark = themeName !== 'light';
   const scheme = schemeId ? TERM_COLOR_SCHEMES.find(s => s.id === schemeId) : undefined;
   const bgOpaque = THEME_TERMINAL_BG[themeName] || (isDark ? '#0c0c0c' : '#eeebe2');
@@ -189,7 +194,9 @@ function buildXtermTheme(themeName: string, hasBg: boolean | undefined, schemeId
     ...base,
     background: bg,
     foreground: fg,
-    cursor: bgOpaque,
+    // AI-agent tabs: cursor painted in bg color = invisible (see comment at
+    // the top of this section). Raw shells get a real, visible caret.
+    cursor: rawShell ? fg : bgOpaque,
     cursorAccent: bgOpaque,
   };
 }
@@ -425,6 +432,10 @@ interface TierTerminalProps {
 function TierTerminalImpl({
   sessionId, tool, toolName, theme, lang, isActive, toolData, folderPath, resumeToken, hasBg, bgUrl, bgType, termColorScheme, termFont,
 }: TierTerminalProps) {
+  // Raw shells (local terminal / remote SSH) have no TUI painting its own
+  // caret — the xterm cursor is the only input-position indicator, so these
+  // tabs keep it visible (issue #95). Drives the theme + CSS below.
+  const isRawShell = tool === 'terminal' || tool === 'remote';
   // Dispatch-only subscription. Never re-renders this component.
   const dispatch = useAppDispatch();
   // Sentinel scanner needs access to the latest state to look up sibling
@@ -524,9 +535,9 @@ function TierTerminalImpl({
       rescaleOverlappingGlyphs: true, // Force ambiguous-width chars (block chars ▀▄█) to single cell width
       // Cursor blink fires a GPU repaint every ~530ms for the entire app
       // lifetime. On laptops (especially Apple Silicon Air without a fan)
-      // that's a constant power draw users feel as warmth. Off by default —
-      // also redundant since the cursor itself is invisible (theme.cursor =
-      // bg color), but kept for renderer paths that ignore the color trick.
+      // that's a constant power draw users feel as warmth. Off in AI-agent
+      // tabs (cursor invisible there anyway) and raw shells alike — a
+      // static, non-blinking caret costs nothing once painted.
       cursorBlink: false,
       // Default `cursorInactiveStyle: 'outline'` makes xterm flip the
       // cursor presentation on blur, which dirties the WebGL buffer and
@@ -534,11 +545,11 @@ function TierTerminalImpl({
       // of the upstream CLI's own caret character (Claude Code, Codex)
       // every time the user clicks anywhere outside the terminal.
       // 'none' suppresses the inactive cursor entirely so blur is a
-      // no-op for the renderer. Cursor is already hidden via theme +
-      // CSS, so this is double-belt; the win is that the redraw stops.
+      // no-op for the renderer. The win is that the redraw stops; in raw
+      // shells the caret simply hides while the terminal is unfocused.
       cursorInactiveStyle: 'none',
       scrollback: 5000,
-      theme: buildXtermTheme(theme, hasBg, termColorScheme),
+      theme: buildXtermTheme(theme, hasBg, termColorScheme, isRawShell),
     });
 
     const fit = new FitAddon();
@@ -585,20 +596,13 @@ function TierTerminalImpl({
         }
       }
 
-      // ── Fix Windows IME candidate window position (issue #88) ──
-      // Windows IME caches the textarea position when it first gains focus.
-      // Subsequent CSS updates are ignored until focus is truly lost and
-      // regained. We trigger a blur/focus cycle on every mousedown to force
-      // IME to re-read the position. This ensures the candidate window appears
-      // at the cursor, not at some stale position.
-      //
-      // Windows-only: macOS/Linux don't have this caching behavior.
-      // Side effect: This also makes paste operations more reliable by
-      // resetting focus state on every click.
-      if (!__IS_LINUX__ && navigator.userAgent.toLowerCase().includes('win')) {
-        // The transparent shell approach has been removed in favor of a simpler
-        // mousedown handler that doesn't interfere with text selection.
-      }
+      // ── Windows IME candidate window position (issue #88) ──
+      // Windows IME caches the helper textarea's position when it first gains
+      // focus; later CSS moves are ignored until focus is truly lost and
+      // regained. The re-anchor + blur/focus cycle lives in the wrap div's
+      // onMouseDown/onClick handlers below — deliberately split across the
+      // gesture, because cycling focus on mousedown breaks xterm drag
+      // selection (issue #92).
 
       // Disable font ligatures on the DOM renderer rows to prevent
       // box-drawing characters from being merged into ligature glyphs.
@@ -1230,8 +1234,8 @@ function TierTerminalImpl({
   useEffect(() => {
     const term = xtermRef.current;
     if (!term) return;
-    term.options.theme = buildXtermTheme(theme, hasBg, termColorScheme);
-  }, [theme, termColorScheme, hasBg]);
+    term.options.theme = buildXtermTheme(theme, hasBg, termColorScheme, isRawShell);
+  }, [theme, termColorScheme, hasBg, isRawShell]);
 
   // ── Terminal font sync (live, no PTY restart) ────────────────────────────
   useEffect(() => {
@@ -1633,15 +1637,18 @@ function TierTerminalImpl({
           setCtxMenu({ x: e.clientX, y: e.clientY, hasSelection: !!xtermRef.current?.hasSelection() });
         }}
         onMouseDown={(e) => {
-          // Windows IME fix (issue #88): on left-click, re-anchor the hidden
-          // .xterm-helper-textarea to the buffer cursor (the TUI input box)
-          // BEFORE the blur/focus cycle, so Windows IME re-reads the input-box
-          // position instead of landing on the click point. Without this, the
-          // candidate window follows the mouse: correct when you click the
-          // input box (mouse == input box), wrong when you click elsewhere.
-          // Coordinate formula matches xterm's own _syncTextArea
-          // (left = cursorX * cellW, top = cursorY * cellH, relative to
-          // .xterm-screen). Left-click only; middle/right have their own paths.
+          // Windows IME fix (issue #88), part 1 of 2: on left-click, re-anchor
+          // the hidden .xterm-helper-textarea to the buffer cursor (the TUI
+          // input box), so Windows IME later re-reads the input-box position
+          // instead of the click point. Coordinate formula matches xterm's own
+          // _syncTextArea (left = cursorX * cellW, top = cursorY * cellH,
+          // relative to .xterm-screen). Left-click only; middle/right have
+          // their own paths.
+          //
+          // The blur/focus cycle that makes IME actually re-read this position
+          // is deliberately NOT here — cycling focus on mousedown interrupts
+          // the in-progress mouse gesture and breaks xterm drag selection
+          // (issue #92). It runs in onClick, once the gesture is over.
           if (!__IS_LINUX__ && navigator.userAgent.toLowerCase().includes('win') && e.button === 0) {
             const term = xtermRef.current;
             const textarea = termRef.current?.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null;
@@ -1653,7 +1660,20 @@ function TierTerminalImpl({
               const cy = term.buffer.active.cursorY;
               textarea.style.left = `${cx * cellW}px`;
               textarea.style.top = `${cy * cellH}px`;
-              // Blur then refocus to force Windows IME to re-read the position
+            }
+          }
+        }}
+        onClick={() => {
+          // Windows IME fix (issue #88), part 2 of 2: the mouse gesture is
+          // complete, so blur/refocus the helper textarea to force Windows IME
+          // to re-read the position anchored on mousedown. Skipped when the
+          // gesture produced a selection — that was a drag-select, not an
+          // intent to type, and cycling focus there serves no purpose
+          // (issue #92).
+          if (!__IS_LINUX__ && navigator.userAgent.toLowerCase().includes('win')) {
+            if (xtermRef.current?.hasSelection()) return;
+            const textarea = termRef.current?.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null;
+            if (textarea) {
               textarea.blur();
               setTimeout(() => textarea.focus(), 0);
             }
@@ -1706,7 +1726,9 @@ function TierTerminalImpl({
           // If no image found, let the event propagate to xterm for normal text paste
         }}
       >
-        <div ref={termRef} className="tier-xterm" />
+        {/* Raw shells get the `raw-shell` class so the CSS cursor-hiding
+            rule skips them (issue #95 — see TierTerminal.css). */}
+        <div ref={termRef} className={`tier-xterm${isRawShell ? ' raw-shell' : ''}`} />
       </div>
 
       {/* Terminal right-click context menu */}

--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -448,6 +448,10 @@ function TierTerminalImpl({
   useEffect(() => { appStateRef.current = _appState; }, [_appState]);
 
   const termRef  = useRef<HTMLDivElement>(null);
+  // Frozen helper-textarea position held for the lifetime of an IME
+  // composition (Windows) — see the compositionstart/end wiring in the
+  // init effect. Null when no composition is active.
+  const imeFrozenRef = useRef<{ left: string; top: string } | null>(null);
   const wrapRef  = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
   const fitRef   = useRef<FitAddon | null>(null);
@@ -603,6 +607,41 @@ function TierTerminalImpl({
       // onMouseDown/onClick handlers below — deliberately split across the
       // gesture, because cycling focus on mousedown breaks xterm drag
       // selection (issue #92).
+      //
+      // Freeze during composition: a TUI redraws on every keystroke and its
+      // buffer cursor can hop between the input box and the output region
+      // mid-composition; xterm's own _syncTextArea drags the helper textarea
+      // (and the IME candidate window with it) along every hop — the "jumpy
+      // candidate" users feel as 乱跳. We pin the textarea at compositionstart
+      // and hold it until compositionend, so the candidate stays put for the
+      // whole word/phrase. Clicks still re-anchor between compositions.
+      if (!__IS_LINUX__ && navigator.userAgent.toLowerCase().includes('win')) {
+        const imeTextarea = termRef.current.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null;
+        if (imeTextarea) {
+          const freeze = () => {
+            imeFrozenRef.current = { left: imeTextarea.style.left, top: imeTextarea.style.top };
+          };
+          const unfreeze = () => { imeFrozenRef.current = null; };
+          imeTextarea.addEventListener('compositionstart', freeze, { capture: true });
+          imeTextarea.addEventListener('compositionend', unfreeze, { capture: true });
+          unlisteners.push(() => {
+            imeTextarea.removeEventListener('compositionstart', freeze, { capture: true });
+            imeTextarea.removeEventListener('compositionend', unfreeze, { capture: true });
+          });
+          // xterm's internal _syncTextArea runs off its own cursor-move
+          // listener (registered at open, before ours), so writing the frozen
+          // spot back here wins within the same synchronous dispatch — no
+          // intermediate paint, no visible jitter.
+          const cursorMoveListener = term.onCursorMove(() => {
+            const f = imeFrozenRef.current;
+            if (f) {
+              imeTextarea.style.left = f.left;
+              imeTextarea.style.top = f.top;
+            }
+          });
+          unlisteners.push(() => cursorMoveListener.dispose());
+        }
+      }
 
       // Disable font ligatures on the DOM renderer rows to prevent
       // box-drawing characters from being merged into ligature glyphs.
@@ -1650,6 +1689,9 @@ function TierTerminalImpl({
           // the in-progress mouse gesture and breaks xterm drag selection
           // (issue #92). It runs in onClick, once the gesture is over.
           if (!__IS_LINUX__ && navigator.userAgent.toLowerCase().includes('win') && e.button === 0) {
+            // Never move the textarea mid-composition — the candidate window
+            // is pinned for the composition's lifetime (see init effect).
+            if (imeFrozenRef.current) return;
             const term = xtermRef.current;
             const textarea = termRef.current?.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null;
             const screenEl = termRef.current?.querySelector('.xterm-screen') as HTMLElement | null;
@@ -1671,6 +1713,9 @@ function TierTerminalImpl({
           // intent to type, and cycling focus there serves no purpose
           // (issue #92).
           if (!__IS_LINUX__ && navigator.userAgent.toLowerCase().includes('win')) {
+            // Blurring now would cancel an in-flight composition — let it
+            // finish; the next click re-anchors.
+            if (imeFrozenRef.current) return;
             if (xtermRef.current?.hasSelection()) return;
             const textarea = termRef.current?.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null;
             if (textarea) {


### PR DESCRIPTION
## 概述

修复三个终端体验问题，根因分别来自 #92 和 #95 中的代码级分析（本 PR 含完整复现/验证记录）。全部改动集中在 `TierTerminal.tsx` / `TierTerminal.css`。

## 1. Windows 拖选被 IME 修复打断（#92 的根因）

v3.1.7 为修 #88（IME 候选框不跟随）在每次左键 `mousedown` 执行 `textarea.blur()` + `setTimeout(focus, 0)`。焦点切换发生在鼠标手势**进行中**，会打断 xterm 的拖选——用户表现为「终端文字无法选中、无法复制」。

为什么维护者无法复现而报告者坚持有问题：双方都对。xterm 的 SelectionService 本身不监听 blur/focus，选择模型不会被清；但 WebView2/Chromium 层在拖拽手势中切换 `document.activeElement` 会中止手势。且双击选词不受影响（离散事件，无需拖动），所以表现为「能双击选、不能拖着选」。

**修复**（保住 #88 的 IME 修复，只改时机）：
- `mousedown` 只做 textarea 位置重锚定（无副作用）
- `blur()`/`focus()` 挪到 `click`（手势结束后）执行，且 `term.hasSelection()` 时跳过——拖选产生了选择，不抢焦点；普通点击无选择，IME 重锚定行为与原来一致

## 2. 选中高亮淡到看不见（#92 的另一半）

`deriveSelectionBg` 的 alpha 为 dark 0.4 / light 0.3，`#c4956a` 调暗后叠在 `#1a1917` 上几乎不可见——相当部分「无法选中」其实是「选中了但看不见」。

**修复**：alpha 提升 dark 0.4→0.55 / light 0.3→0.45（fallback 值同步）。保留 RGB×0.8 的品牌调暗，只动透明度。

## 3. raw-shell / remote tab 光标完全不可见（#95）

光标被四重手段抹掉（`theme.cursor = bgOpaque`、`cursorBlink: false`、`cursorInactiveStyle: 'none'`、CSS `display:none !important`）。对 AI TUI tab 这是合理优化（TUI 自绘光标），但裸 shell / SSH tab **没有任何东西补画光标**，用户完全不知道输入点在哪。

**修复**：按 tab 类型区分（`tool === 'terminal' || 'remote'`，无需新 prop）：
- theme 里 raw-shell tab 的 `cursor` 用前景色（TUI tab 保持 `bgOpaque` 不变）
- CSS 隐藏规则收窄为 `.tier-xterm:not(.raw-shell) ...`
- `cursorBlink: false` 与 `cursorInactiveStyle: 'none'` 不变——保留省电/防闪烁收益，光标静止可见、失焦隐藏

## 4. IME 候选框在输入过程中乱跳

TUI 每次按键都重绘，buffer 光标可能在输入框与输出区之间跳动；xterm 的 `_syncTextArea` 拖着 helper textarea（和候选框）跟着每一次跳动。用户在拼音输入全程看到候选框四处乱跳。

**修复**：`compositionstart` 时冻结 textarea 位置直到 `compositionend`（通过 `onCursorMove` 回写冻结位置，在 xterm 内部 sync 之后执行，无中间帧闪烁）。一个词/短语的输入全程候选框纹丝不动；点击仍在组合间隙重新锚定。顺带：composition 进行中跳过 click 的 blur/focus（否则会取消正在输入的拼音）。

## 验证

Windows 11 + WebView2 实机测试通过：
- 拖选恢复、右键复制正常；双击选词正常
- 选中高亮肉眼清晰可见
- 「终端」tab 光标可见且不闪烁；AI agent tab 光标仍隐藏（行为不变）
- 中文输入法：Claude tab 候选框精确跟随输入框；组合输入全程不再乱跳

**已知遗留**：kimi-code 的 TUI buffer 光标位置本身有偏差（#95 讨论中维护者已确认是 kimi-code 侧 bug），导致其候选框锚定点偏移——需上游修复，不在本 PR 范围。

Fixes #92, fixes #95.
