### PR TITLE
feat(tools): Kimi Code 升级 T1 —— hook 通道接入动态岛状态总线

### DIFF
--- a/src-ui/src/components/center/CenterPanel.tsx
+++ b/src-ui/src/components/center/CenterPanel.tsx
@@ -422,9 +422,10 @@ const VALID_PIN_KEYS = new Set<string>([
 ]);
 
 // Tabs that show the status-grid ("Dynamic Island") indicator: every AI CLI.
-// Hook-wired tools (claude/codex/opencode/mimocode/hermes) drive it live off
-// session.agentStatus; the rest have no status bus and sit at static 'idle'
-// green — the "fake island" baseline so every AI-CLI tab reads consistently.
+// Hook-wired tools (claude/codex/opencode/mimocode/hermes/kimicode) drive it
+// live off session.agentStatus; the rest have no status bus and sit at
+// static 'idle' green — the "fake island" baseline so every AI-CLI tab reads
+// consistently.
 // Non-CLI tabs (terminal/remote/history/splits/installer) get no indicator.
 const TAB_STATUS_TOOLS = new Set<string>([
   'claude', 'codex', 'grok', 'opencode', 'mimocode', 'hermes',
@@ -542,7 +543,7 @@ export function CenterPanel() {
   // the order here is the launchpad's preferred presentation order.
   const BUILTIN_AI_CLI_FALLBACK: { key: ToolType; label: string }[] = [
     'claude', 'opencode', 'mimocode', 'openclaw', 'codex', 'grok', 'antigravity', 'qwen', 'hermes',
-    // Pi & Kimi Code (T2) + Crush/Aider/Goose/Copilot (T3 launch-only).
+    // Pi (T2) + Crush/Aider/Goose/Copilot (T3 launch-only). Kimi Code is T1.
     'pi', 'crush', 'aider', 'kimicode', 'goose', 'copilot',
   ].map((key) => ({ key: key as ToolType, label: getToolDisplayName(key) }));
 
@@ -1133,10 +1134,11 @@ export function CenterPanel() {
       case 'codex': return { icon: <SvgCodex />, title: cwd ?? getToolDisplayName('codex'), tooltip: pathTip };
       case 'grok': return { icon: <SvgGrok />, title: cwd ?? getToolDisplayName('grok'), tooltip: pathTip };
       case 'antigravity': return { icon: <SvgAntigravity />, title: cwd ?? getToolDisplayName('antigravity'), tooltip: pathTip };
-      // Hookless CLIs (Pi/Kimi Code T2 + Crush/Aider/Goose/Copilot T3) —
-      // directory-aware tab like the AI CLIs above (icon + cwd basename).
-      // No real status bus, so they get the static "fake" island via
-      // TAB_STATUS_TOOLS below.
+      // Directory-aware tabs (icon + cwd basename). Pi and the T3 set
+      // (Crush/Aider/Goose/Copilot) are hookless — no real status bus, so
+      // they get the static "fake" island via TAB_STATUS_TOOLS below.
+      // Kimi Code renders the same shape but is hook-wired (T1): its
+      // island is live off session.agentStatus.
       case 'pi': return { icon: <SvgPi />, title: cwd ?? getToolDisplayName('pi'), tooltip: pathTip };
       case 'crush': return { icon: <SvgCrush />, title: cwd ?? getToolDisplayName('crush'), tooltip: pathTip };
       case 'aider': return { icon: <SvgAider />, title: cwd ?? getToolDisplayName('aider'), tooltip: pathTip };
@@ -1289,8 +1291,8 @@ export function CenterPanel() {
                 {/* Indicator gate — every AI CLI gets the island (see
                     TAB_STATUS_TOOLS). Hook-wired tools (claude/codex/opencode
                     via forwarders, mimocode via its preset-driven status
-                    ticker, hermes) drive color off session.agentStatus.
-                    Hookless CLIs (antigravity/qwen/openclaw/pi/kimicode, plus
+                    ticker, hermes, kimicode) drive color off session.agentStatus.
+                    Hookless CLIs (antigravity/qwen/openclaw/pi, plus
                     the T3 set crush/aider/goose/copilot) have no agentStatus,
                     so the grid sits at
                     static 'idle' green — the "fake island" baseline. Non-CLI

--- a/src/hook_forwarder.rs
+++ b/src/hook_forwarder.rs
@@ -1,7 +1,9 @@
 // Coffee CLI — native hook forwarder
 //
-// Invoked as a Claude Code hook (`<exe> __hook`, event JSON on stdin) or a
-// Codex `notify` target (`<exe> __codex-notify <json>`, payload as final
+// Invoked as a Claude Code hook (`<exe> __hook`, event JSON on stdin), a
+// Kimi Code hook (`<exe> __kimi-hook`, same Claude-shaped stdin JSON), a
+// Codex hooks-system target (`<exe> __codex-hook`, stdin JSON), or a Codex
+// `notify` target (`<exe> __codex-notify <json>`, payload as final
 // argv). Maps the event to Coffee CLI's 3-state agent status and forwards a
 // compact JSON line to the Rust hook server over loopback TCP.
 //
@@ -73,6 +75,16 @@ pub fn run_codex_notify(args: &[String]) -> ! {
 /// / Stop. Never returns.
 pub fn run_codex_hook() -> ! {
     let _ = forward_codex_hook();
+    std::process::exit(0);
+}
+
+/// `<exe> __kimi-hook` — Kimi Code hooks (stdin protocol, Claude-shaped JSON
+/// with `hook_event_name`). Installed by `install_kimi` as `[[hooks]]`
+/// entries in ~/.kimi-code/config.toml. Kimi may append a hook's stdout to
+/// the model context, so this path must stay stdout-silent — we only ever
+/// write to the loopback socket. Never returns.
+pub fn run_kimi_hook() -> ! {
+    let _ = forward_kimi();
     std::process::exit(0);
 }
 
@@ -150,6 +162,48 @@ fn forward_codex_hook() -> Option<()> {
 
     post(ctx.port, &ctx.tab_id, &ctx.tool, &status, &event);
     Some(())
+}
+
+/// stdin hook path for Kimi Code (9 events installed as `[[hooks]]` in
+/// ~/.kimi-code/config.toml). Reads the payload the same way Claude's
+/// `__hook` does — Kimi's hook JSON is Claude-shaped, with
+/// `hook_event_name` naming the event. No tool gate needed beyond
+/// HookCtx::from_env: kimi sessions started outside Coffee CLI don't carry
+/// the COFFEE_CLI_* env vars, so the forwarder no-ops there (same as
+/// Claude).
+fn forward_kimi() -> Option<()> {
+    let ctx = HookCtx::from_env()?;
+
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf).ok()?;
+    // Tolerate a leading UTF-8 BOM (see forward_claude).
+    let buf = buf.trim_start_matches('\u{feff}');
+    let data: Value = serde_json::from_str(buf).ok()?;
+
+    let event = data
+        .get("hook_event_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let status = map_kimi_status(&event);
+
+    post(ctx.port, &ctx.tab_id, &ctx.tool, status, &event);
+    Some(())
+}
+
+/// Map a Kimi Code hook event to a tab status. Same bucketing strategy as
+/// map_claude_status: known-idle and permission-prompt events get their own
+/// color, everything else — including unknown or missing event names — is
+/// busy (working). Never returns None: a recognized hook firing at all means
+/// the agent is alive and doing something.
+fn map_kimi_status(event: &str) -> &'static str {
+    match event {
+        "Stop" | "StopFailure" | "Interrupt" | "SessionEnd" => "idle",
+        "PermissionRequest" => "wait_input",
+        // UserPromptSubmit / PreToolUse / PostToolUse / PermissionResult,
+        // plus anything unrecognized → busy.
+        _ => "working",
+    }
 }
 
 /// Map a Codex hooks-system event to a tab status. Covers the 4 events we

--- a/src/hook_installer.rs
+++ b/src/hook_installer.rs
@@ -1,7 +1,7 @@
 // Coffee CLI Hook Installer
 //
-// At app launch, ensure all three integrated CLIs are wired to the dynamic
-// island status bus:
+// At app launch, ensure the hook-capable integrated CLIs are wired to the
+// dynamic island status bus:
 //
 // The forwarder is the Coffee CLI binary itself (`<exe> __hook` /
 // `<exe> __codex-notify`, implemented in hook_forwarder.rs) — NOT a Python
@@ -37,6 +37,12 @@
 //        gate (third-party plugins don't load until allow-listed in
 //        <HERMES_HOME>/config.yaml). We let Hermes' own command do the
 //        YAML edit so we don't have to YAML-round-trip user config.
+//
+//   Kimi Code
+//     1. ~/.kimi-code/config.toml — 9 `[[hooks]]` array-of-tables entries
+//        pointing at `<exe> __kimi-hook` (see install_kimi). Kimi's stdin
+//        hook protocol is Claude-shaped (`hook_event_name` JSON on stdin),
+//        so the same native-forwarder pattern drives the 3-color bus.
 //
 // IMPORTANT — Claude event list discipline:
 // Claude Code rejects the *entire* hooks block if it contains an unknown
@@ -166,6 +172,7 @@ fn dispatch_install(tool: &crate::tools::ToolDescriptor, home: &Path) {
             ensure_opencode_tui_theme_default(home, "mimocode");
         }
         "hermes" => install_hermes(home),
+        "kimicode" => install_kimi(home),
         other => {
             eprintln!(
                 "[hook-installer] tool '{}' declares a hook surface but has no installer — \
@@ -1034,6 +1041,156 @@ fn patch_codex_features(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+// ─── Kimi Code hooks (config.toml [[hooks]]) ─────────────────────────────────
+//
+// Kimi Code reads `[[hooks]]` array-of-tables entries from
+// ~/.kimi-code/config.toml and pipes a Claude-shaped JSON payload
+// (`hook_event_name`, `session_id`, `cwd`, …) to the hook command's stdin —
+// so the forwarder is the same native-subcommand pattern as Claude/Codex:
+// `<exe> __kimi-hook` (hook_forwarder.rs::run_kimi_hook).
+//
+// STRICT config constraint (high risk): Kimi Code rejects the *entire*
+// config.toml if a `[[hooks]]` table carries any key other than
+// event / matcher / command / timeout. We therefore emit exactly
+// event + command + timeout per block (matcher omitted = match all) and
+// nothing else — no extra keys, ever.
+//
+// Merge discipline mirrors patch_codex_config: line-edited (not parsed) so
+// the user's comments, key order, and [providers.*] / [models.*] tables
+// survive verbatim. `[[hooks]]` blocks append cleanly at EOF in TOML
+// array-of-tables syntax, so appending ours after user content is safe.
+
+/// Kimi hooks subcommand — stdin protocol (Claude-shaped JSON), installed
+/// into ~/.kimi-code/config.toml `[[hooks]]` entries.
+const KIMI_HOOK_SUBCOMMAND: &str = "__kimi-hook";
+
+/// The 9 Kimi events we register — all matcher-less (match every tool) with
+/// the default 30s timeout. SessionStart / Subagent* / Notification /
+/// PreCompact / PostCompact are deliberately excluded: pure status noise for
+/// the tab dot, and the frontend's 30s auto-idle covers a missed Stop.
+const KIMI_HOOK_EVENTS: &[&str] = &[
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "PermissionRequest",
+    "PermissionResult",
+    "Stop",
+    "StopFailure",
+    "Interrupt",
+    "SessionEnd",
+];
+
+/// Kimi Code hooks — merge our `[[hooks]]` entries into
+/// ~/.kimi-code/config.toml. Errors are logged, never fatal.
+fn install_kimi(home: &Path) {
+    let cmd = match hook_command(KIMI_HOOK_SUBCOMMAND) {
+        Some(c) => c,
+        None => {
+            eprintln!("[hook-installer] current_exe() failed — cannot install kimi hooks");
+            return;
+        }
+    };
+    let config_path = home.join(".kimi-code").join("config.toml");
+    if let Err(e) = patch_kimi_config(&config_path, &cmd) {
+        eprintln!(
+            "[hook-installer] failed to patch {}: {}",
+            config_path.display(),
+            e
+        );
+    }
+}
+
+/// Merge our 9 `[[hooks]]` entries into ~/.kimi-code/config.toml. Creates the
+/// file (and parent dir) if missing; preserves all existing content verbatim
+/// otherwise. Idempotent: any prior `[[hooks]]` block whose command ends in
+/// our `__kimi-hook` token (stale exe paths included) is stripped — header
+/// and its field lines together — before the fresh set is appended. User-
+/// written `[[hooks]]` entries (other commands, any event) are kept.
+fn patch_kimi_config(path: &Path, command: &str) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let existing = if path.exists() {
+        fs::read_to_string(path).unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    // Strip our prior entries. A "block" is a `[[...]]` array-of-tables
+    // header line plus the lines up to (not including) the next table
+    // header; it's ours iff it contains a `command` line whose last token
+    // is `__kimi-hook` (same last-token discipline as is_coffee_entry, so a
+    // user hook whose path merely *contains* the token is never stripped).
+    let lines: Vec<&str> = existing.lines().collect();
+    let mut kept: Vec<&str> = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if lines[i].trim_start().starts_with("[[") {
+            let mut j = i + 1;
+            while j < lines.len() && !lines[j].trim_start().starts_with('[') {
+                j += 1;
+            }
+            if !lines[i..j].iter().any(|l| is_coffee_kimi_command_line(l)) {
+                kept.extend(&lines[i..j]);
+            }
+            i = j;
+        } else {
+            kept.push(lines[i]);
+            i += 1;
+        }
+    }
+    // Drop trailing blank lines left behind by the strip so the re-appended
+    // block doesn't drift further down the file on every reinstall.
+    while kept.last().map(|l| l.trim().is_empty()).unwrap_or(false) {
+        kept.pop();
+    }
+
+    // TOML basic strings escape backslashes and quotes — the hook command is
+    // `"<exe>" __kimi-hook` with literal quotes around the exe path.
+    let escaped = command.replace('\\', "\\\\").replace('"', "\\\"");
+
+    let mut out = String::new();
+    if existing.trim().is_empty() {
+        out.push_str("# Coffee CLI registered these hooks for the dynamic-island status\n# indicator. Safe to remove if you don't use Coffee CLI — the command\n# no-ops when COFFEE_CLI_* env vars aren't set.\n");
+    } else {
+        for l in &kept {
+            out.push_str(l);
+            out.push('\n');
+        }
+        out.push('\n');
+    }
+    for (idx, event) in KIMI_HOOK_EVENTS.iter().enumerate() {
+        if idx > 0 {
+            out.push('\n');
+        }
+        out.push_str("[[hooks]]\n");
+        out.push_str(&format!("event = \"{}\"\n", event));
+        out.push_str(&format!("command = \"{}\"\n", escaped));
+        out.push_str("timeout = 30\n");
+    }
+
+    fs::write(path, out)?;
+    Ok(())
+}
+
+/// Text-level sentinel for patch_kimi_config: a `command = "..."` line is
+/// ours iff the last whitespace-delimited token inside the quotes is
+/// `__kimi-hook`. Mirrors is_coffee_entry's last-token discipline so a user
+/// hook whose path merely *contains* "__kimi-hook" (e.g.
+/// /home/u/.__kimi-hooks/lint.sh) is never misclassified as ours.
+fn is_coffee_kimi_command_line(line: &str) -> bool {
+    let t = line.trim();
+    let Some(rest) = t.strip_prefix("command") else {
+        return false;
+    };
+    let Some(value) = rest.trim_start().strip_prefix('=') else {
+        return false;
+    };
+    let value = value.trim().trim_end_matches('"');
+    value.split_whitespace().last() == Some(KIMI_HOOK_SUBCOMMAND)
+}
+
 // ─── Broken-bin repair (Windows) ────────────────────────────────────────────
 //
 // `opencode upgrade` re-runs `npm install -g opencode-ai` to rewrite the
@@ -1370,5 +1527,125 @@ mod tests {
         assert!(after.contains("hooks = true"));
         let _ = fs::remove_dir_all(&dir);
     }
-}
 
+    // ─── Kimi Code config.toml `[[hooks]]` ──────────────────────────────────
+    // Cargo.toml has no toml/toml_edit dependency, so these are text-level
+    // assertions (per the line-editing design — a parsed round-trip would
+    // defeat the comment-preservation goal anyway).
+
+    fn fresh_kimi_dir(name: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("coffee-kimi-test-{}-{}", name, std::process::id()));
+        let _ = fs::remove_dir_all(&p);
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn kimi_config_creates_with_9_events() {
+        let dir = fresh_kimi_dir("create");
+        let cfg = dir.join("config.toml");
+        patch_kimi_config(&cfg, "\"/fake/exe\" __kimi-hook").unwrap();
+
+        let text = fs::read_to_string(&cfg).unwrap();
+        assert_eq!(text.matches("[[hooks]]").count(), 9, "one block per event: {}", text);
+        assert_eq!(text.matches("__kimi-hook").count(), 9, "one command per block: {}", text);
+        for ev in [
+            "UserPromptSubmit", "PreToolUse", "PostToolUse", "PermissionRequest",
+            "PermissionResult", "Stop", "StopFailure", "Interrupt", "SessionEnd",
+        ] {
+            assert!(text.contains(&format!("event = \"{}\"", ev)), "missing event {}: {}", ev, text);
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn kimi_config_preserves_existing_content() {
+        let dir = fresh_kimi_dir("preserve");
+        let cfg = dir.join("config.toml");
+        // User config: comments, a top-level key, a regular table, and their
+        // own hand-written [[hooks]] entry — all must survive verbatim.
+        let original = "# my kimi config\nmodel = \"k2\"\n\n[providers.foo]\nbase_url = \"https://x\"\n\n[[hooks]]\nevent = \"Stop\"\ncommand = \"echo user\"\ntimeout = 5\n";
+        fs::write(&cfg, original).unwrap();
+        patch_kimi_config(&cfg, "\"/fake/exe\" __kimi-hook").unwrap();
+
+        let after = fs::read_to_string(&cfg).unwrap();
+        assert!(after.contains("# my kimi config"), "comment preserved: {}", after);
+        assert!(after.contains("model = \"k2\""), "top-level key preserved: {}", after);
+        assert!(after.contains("[providers.foo]\nbase_url = \"https://x\""), "user table preserved: {}", after);
+        assert!(after.contains("command = \"echo user\""), "user's own hook preserved: {}", after);
+        assert!(after.contains("timeout = 5"), "user hook fields preserved: {}", after);
+        // Our blocks append AFTER the user's content.
+        let pos_user = after.find("command = \"echo user\"").unwrap();
+        let pos_ours = after.find("__kimi-hook").unwrap();
+        assert!(pos_user < pos_ours, "ours appended at end: {}", after);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn kimi_config_idempotent_no_duplicates() {
+        let dir = fresh_kimi_dir("idempotent");
+        let cfg = dir.join("config.toml");
+        // Install 3x — each should strip the prior entries and add one fresh
+        // set, never accumulating duplicates.
+        for _ in 0..3 {
+            patch_kimi_config(&cfg, "\"/fake/exe\" __kimi-hook").unwrap();
+        }
+        let text = fs::read_to_string(&cfg).unwrap();
+        assert_eq!(text.matches("[[hooks]]").count(), 9, "reinstall accumulated blocks: {}", text);
+        assert_eq!(text.matches("__kimi-hook").count(), 9, "reinstall accumulated commands: {}", text);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn kimi_config_reinstall_strips_stale_keeps_user_hooks() {
+        let dir = fresh_kimi_dir("stale");
+        let cfg = dir.join("config.toml");
+        // Seed a stale coffee entry (old exe path — e.g. pre-upgrade) next to
+        // a user's own hook on the same event.
+        let seeded = "[[hooks]]\nevent = \"Stop\"\ncommand = \"\\\"/old/path/coffee-cli.exe\\\" __kimi-hook\"\ntimeout = 30\n\n[[hooks]]\nevent = \"Stop\"\ncommand = \"echo user\"\ntimeout = 5\n";
+        fs::write(&cfg, seeded).unwrap();
+        patch_kimi_config(&cfg, "\"/new/exe\" __kimi-hook").unwrap();
+
+        let after = fs::read_to_string(&cfg).unwrap();
+        assert!(!after.contains("/old/path"), "stale coffee entry stripped: {}", after);
+        assert_eq!(after.matches("__kimi-hook").count(), 9, "exactly one fresh set: {}", after);
+        assert!(after.contains("command = \"echo user\""), "user hook kept: {}", after);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn kimi_config_blocks_have_only_allowed_fields() {
+        // Kimi rejects the ENTIRE config.toml if a [[hooks]] table carries
+        // any key beyond event/matcher/command/timeout. Verify every line
+        // inside our generated blocks is one of the three we intend (matcher
+        // omitted by design) — no stray keys can sneak in.
+        let dir = fresh_kimi_dir("fields");
+        let cfg = dir.join("config.toml");
+        patch_kimi_config(&cfg, "\"/fake/exe\" __kimi-hook").unwrap();
+
+        let text = fs::read_to_string(&cfg).unwrap();
+        assert!(!text.contains("matcher"), "no matcher keys: {}", text);
+        let mut in_block = false;
+        for line in text.lines() {
+            let t = line.trim();
+            if t.starts_with("[[hooks]]") {
+                in_block = true;
+                continue;
+            }
+            if t.starts_with('[') {
+                in_block = false;
+                continue;
+            }
+            if !in_block || t.is_empty() || t.starts_with('#') {
+                continue;
+            }
+            assert!(
+                t.starts_with("event = ") || t.starts_with("command = ") || t.starts_with("timeout = "),
+                "unexpected field in [[hooks]] block: {:?}",
+                line
+            );
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src/hook_server.rs
+++ b/src/hook_server.rs
@@ -6,6 +6,7 @@
 //   - scripts/coffee-cli-hook.py            — Claude Code stdin hooks
 //   - scripts/coffee-cli-codex-notify.py    — Codex `notify` argv-tail
 //   - scripts/coffee-cli-opencode-plugin.js — OpenCode plugin events
+//   - `<exe> __kimi-hook` (hook_forwarder.rs) — Kimi Code [[hooks]] events
 //
 // Single payload kind:
 //

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,9 @@ use anyhow::Result;
 fn main() -> Result<()> {
     // ── Native hook forwarder (fast path) ───────────────────────────────
     // Invoked by Claude Code (`<exe> __hook`), Codex hooks (`<exe>
-    // __codex-hook`, stdin JSON), and Codex legacy notify (`<exe>
-    // __codex-notify <json>`) to forward agent status to the dynamic
+    // __codex-hook`, stdin JSON), Codex legacy notify (`<exe>
+    // __codex-notify <json>`), and Kimi Code hooks (`<exe> __kimi-hook`,
+    // Claude-shaped stdin JSON) to forward agent status to the dynamic
     // island. This MUST run before any GUI / Linux-backend / PATH-inherit
     // setup below — the PATH fix spawns a login shell, which we don't want
     // firing on every tool-call hook. Each arm calls process::exit and
@@ -35,6 +36,7 @@ fn main() -> Result<()> {
             Some("__hook") => hook_forwarder::run_claude_hook(),
             Some("__codex-hook") => hook_forwarder::run_codex_hook(),
             Some("__codex-notify") => hook_forwarder::run_codex_notify(&argv),
+            Some("__kimi-hook") => hook_forwarder::run_kimi_hook(),
             _ => {}
         }
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -446,8 +446,9 @@ pub const AGENT_PRESETS: &[AgentPreset] = &[
     // (canonical `-S, --session`, verified against `kimi --help`). Token is
     // `session_<uuid>` from session_index.jsonl, sourced by find_kimi_sessions
     // (Kimi doesn't echo the id to stdout, so session_id_pattern is None).
-    // prompt_markers `❯` is a guess — Kimi is hook-less (static fake-island
-    // green); settle-silence fallback covers a wrong marker.
+    // prompt_markers `❯` is a guess — the settle-silence fallback covers a
+    // wrong marker; the live status dot comes from the `__kimi-hook`
+    // forwarder (hook_installer.rs::install_kimi), not these markers.
     AgentPreset {
         tool_name: "kimicode",
         resume_program: Some("kimi"),
@@ -731,12 +732,12 @@ pub fn spawn(
         cmd.env("COFFEE_CODE_LOCALE", loc);
     }
 
-    // ── Hook status injection (claude / codex / opencode / hermes) ───────
+    // ── Hook status injection (claude / codex / opencode / hermes / kimi) ──
     // Each integrated CLI has its own forwarder, but they all share the same
     // env-var contract:
     //   COFFEE_CLI_TAB_ID    — which tab status events should route to
     //   COFFEE_CLI_HOOK_PORT — loopback port of the Rust hook server
-    //   COFFEE_CLI_TOOL      — "claude" | "codex" | "opencode" | "mimocode" | "hermes"
+    //   COFFEE_CLI_TOOL      — "claude" | "codex" | "opencode" | "mimocode" | "hermes" | "kimicode"
     // Forwarders:
     //   claude    — coffee-cli-hook.py (Claude Code stdin hook protocol)
     //   codex     — coffee-cli-codex-notify.py (Codex `notify` config, JSON
@@ -748,10 +749,13 @@ pub fn spawn(
     //               `hermes plugins enable coffee-cli-status`. HERMES_HOME
     //               is `%LOCALAPPDATA%\hermes` on Windows, `~/.hermes`
     //               elsewhere — see tools/hermes.rs::hermes_home.)
+    //   kimicode  — `<exe> __kimi-hook` native forwarder (Kimi Code
+    //               [[hooks]] in ~/.kimi-code/config.toml, Claude-shaped
+    //               stdin JSON — see hook_installer.rs::install_kimi)
     // Forwarders no-op if any of these env vars are missing — they're safe to
     // leave installed even when Coffee CLI isn't the launcher.
     if let Some(tname) = tool_name.as_deref() {
-        if matches!(tname, "claude" | "codex" | "opencode" | "hermes" | "mimocode") {
+        if matches!(tname, "claude" | "codex" | "opencode" | "hermes" | "mimocode" | "kimicode") {
             use tauri::Manager;
             let port = app
                 .state::<crate::server::AppState>()

--- a/src/tools/kimicode.rs
+++ b/src/tools/kimicode.rs
@@ -1,5 +1,5 @@
-//! Kimi Code — second-class (T2) integration: brand icon + one-click
-//! launch + session-history scanning + auto-resume.
+//! Kimi Code — first-class (T1) integration: brand icon + one-click
+//! launch + session-history scanning + auto-resume + live tab status.
 //!
 //! Moonshot AI's `kimi` binary (npm `@moonshot-ai/kimi-code`). Sessions
 //! live under a flat `~/.kimi-code/` root (same path on every OS; override
@@ -21,7 +21,10 @@
 //! Resume: `kimi --session <sessionId>` (canonical `-S, --session` flag,
 //! verified against `kimi --help`). Token shape `session_<uuid>`.
 //!
-//! No hook surface (no live Dynamic Island — static "fake island" green).
+//! Hook surface (T1): `[[hooks]]` entries in `~/.kimi-code/config.toml`
+//! (written by hook_installer's `install_kimi`) point at `<exe> __kimi-hook`;
+//! the forwarder (hook_forwarder.rs `run_kimi_hook`) maps Kimi's
+//! Claude-shaped stdin events to the 3-state tab status bus.
 //! Registered in `TOOLS` for display name + PATH probe + launch binary +
 //! history. Launchpad tile is the frontend's hardcoded AGENT_CATALOG.
 
@@ -32,7 +35,7 @@ pub static DESCRIPTOR: ToolDescriptor = ToolDescriptor {
     display_name: "Kimi Code",
     binary_name: "kimi",
     skill_dir_relative: None,
-    has_hook_surface: false,
+    has_hook_surface: true,
     // ~/.kimi-code/ — flat on all OS (override KIMI_CODE_HOME). Bypasses
     // the file-walk pipeline; server.rs `kimi_root` + `find_kimi_sessions`
     // read session_index.jsonl + state.json.

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -252,9 +252,9 @@ mod mimocode;
 mod openclaw;
 mod opencode;
 mod qwen;
-// Lower-tier tools — see each module's doc comment for its tier (Pi &
-// Kimi Code are T2 with history; Aider/Crush/Goose/Copilot are T3
-// launch-only, no history/hook surface).
+// Lower-tier tools — see each module's doc comment for its tier (Pi is T2
+// with history; Aider/Crush/Goose/Copilot are T3 launch-only, no
+// history/hook surface). Kimi Code was promoted to T1 (hook-wired).
 mod aider;
 mod copilot;
 mod crush;
@@ -279,10 +279,12 @@ pub static TOOLS: &[&ToolDescriptor] = &[
     // Order here doesn't affect the launchpad (that list is hardcoded in the
     // frontend); it only needs to be in the registry for list_tools + scanning.
     &mimocode::DESCRIPTOR,
-    // Pi & Kimi Code are T2 (history + heatmap + changes + resume; see their
-    // module docs). The other four — Crush / Aider / Goose / Copilot — are T3
-    // launch-only: display name + PATH probe + launch binary, history_shape:
-    // None and has_hook_surface: false.
+    // Pi is T2 (history + heatmap + changes + resume; see its module doc).
+    // Kimi Code is T1 — hook-wired via ~/.kimi-code/config.toml `[[hooks]]`
+    // (install_kimi), same T2 features as Pi otherwise. The other four —
+    // Crush / Aider / Goose / Copilot — are T3 launch-only: display name +
+    // PATH probe + launch binary, history_shape: None and
+    // has_hook_surface: false.
     &pi::DESCRIPTOR,
     &crush::DESCRIPTOR,
     &aider::DESCRIPTOR,


### PR DESCRIPTION
## 概述

实现 #45 的剩余部分：Kimi Code 自 2.9.1 起已有 T2 集成（一键启动、历史扫描、auto-resume），但 `has_hook_surface: false`——状态灯是静态假绿点，任务板不联动。本 PR 通过 kimi-code 官方的 hooks 系统把它提升到 T1。

## 协议依据

kimi-code（npm `@moonshot-ai/kimi-code`，实测 0.26.0）的 hooks 与 Claude Code 协议同构：

- 配置文件 `~/.kimi-code/config.toml` 的 `[[hooks]]` 数组，字段仅允许 `event`/`matcher`/`command`/`timeout`——**多写任何字段会导致整份配置加载失败**
- 触发时经 stdin 传 JSON（`hook_event_name`/`session_id`/`cwd`…），与 Claude 的 `__hook` 转发器同形
- `matcher` 省略即匹配全部；fail-open 设计；exit 0 时 stdout 可能被追加到模型上下文

## 改动

- **`hook_installer.rs`**：新增 `install_kimi`，merge 写入 9 个 `[[hooks]]` 条目（`UserPromptSubmit`/`PreToolUse`/`PostToolUse`/`PermissionRequest`/`PermissionResult`/`Stop`/`StopFailure`/`Interrupt`/`SessionEnd`，均省略 matcher，timeout 30）。行编辑保注释（参照 `patch_codex_config`）、哨兵判重幂等（`__kimi-hook` 尾 token 判据，同 `is_coffee_entry`）；块内严格只有 event/command/timeout 三个字段。不注册 SessionStart/Subagent*/Notification/PreCompact/PostCompact（状态噪声，前端 30s auto-idle 已兜底）。
- **`hook_forwarder.rs`**：新增 `__kimi-hook` 子命令 + `map_kimi_status`：working（UserPromptSubmit/PreToolUse/PostToolUse/PermissionResult）、wait_input（PermissionRequest）、idle（Stop/StopFailure/Interrupt/SessionEnd），缺省归 working。stdout 保持静默。
- **`main.rs`**：fast-path 加 `__kimi-hook` arm。
- **`terminal.rs`**：spawn env 注入白名单加 `kimicode`（否则 hook 永远 no-op）。
- **`kimicode.rs`**：`has_hook_surface: true` + 注释更新。
- **前端**：仅注释更新——`TAB_STATUS_TOOLS` 本就包含 kimicode，事件一到状态灯自动变真，零逻辑改动。

## 测试

- 新增 5 个单元测试：空文件创建 9 事件 / 保留用户原有内容与注释 / 三次重装幂等 / 剔除旧 coffee 条目但保留用户手写 hooks / 块内字段白名单校验。`cargo test` 72/72 通过；`cargo check`、`npm run build` 双绿
- 端到端冒烟：无 env / 有 env 无 server / 垃圾 stdin 三种路径均 exit 0 且 stdout/stderr 完全静默
- Windows 11 实机验证：Kimi tab 状态灯随真实事件变化（工作中/等待输入/空闲）

Refs #45.
