### PR TITLE
feat(history): 会话记录增加 agent 筛选下拉 + 工具名可搜索

### DIFF
--- a/src-ui/src/components/right/HistoryBoard.css
+++ b/src-ui/src/components/right/HistoryBoard.css
@@ -135,3 +135,99 @@
   background: var(--bg-hover);
   border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
 }
+
+/* ─── Agent filter dropdown ─── */
+/* Search row: the input takes the remaining width, the filter trigger hugs
+   the right edge. */
+.agent-session-search-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.agent-session-search-row .agent-session-search-wrap {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+.history-tool-filter-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-2);
+  font-size: 12px;
+  font-family: var(--font, system-ui);
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.history-tool-filter-trigger:hover {
+  background: var(--bg-hover);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+}
+.history-tool-filter-trigger.active {
+  border-color: var(--accent);
+  color: var(--text-1);
+}
+.history-tool-filter-label {
+  max-width: 72px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.history-tool-filter-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+.history-tool-filter-menu {
+  /* Same opacity fix as Explorer's .ctx-menu — --bg-card is ~3% white in
+     dark themes, so a portaled menu floating over the session list reads
+     as transparent. Layer --bg-panel over --bg-app so Light theme's
+     translucent panel still reads opaque. Glass shape gets its frosted
+     look from the [data-shape="glass"] override in global.css. */
+  background-color: var(--bg-app);
+  background-image: linear-gradient(var(--bg-panel), var(--bg-panel));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.20), 0 6px 20px rgba(0, 0, 0, 0.22);
+  padding: 4px;
+  z-index: 1000;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.history-tool-filter-opt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-xs);
+  color: var(--text-1);
+  font-size: 12.5px;
+  font-family: var(--font, system-ui);
+  text-align: left;
+  cursor: pointer;
+}
+.history-tool-filter-opt:hover {
+  background: var(--bg-hover);
+}
+.history-tool-filter-opt.active {
+  color: var(--accent);
+}
+.history-tool-filter-opt-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.history-tool-filter-count {
+  color: var(--text-3);
+  font-size: 11px;
+}

--- a/src-ui/src/components/right/HistoryBoard.tsx
+++ b/src-ui/src/components/right/HistoryBoard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
 import { useT } from '../../i18n/useT';
 import { useAppState } from '../../store/app-state';
 import { isTauri } from '../../tauri';
@@ -118,6 +119,48 @@ export function HistoryBoard() {
   const isLoading = isTauri && (status === 'idle' || status === 'loading') && cachedSessions.length === 0;
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
+  // Agent filter dropdown: which tool's sessions to show (null = all). The
+  // option list is derived from the *visible* (unhidden) data so its counts
+  // always match what the list would show.
+  const [activeTool, setActiveTool] = useState<string | null>(null);
+  // The filter is a themed dropdown (NOT a native <select> — that can't be
+  // themed, and can't even open while a terminal is active because the
+  // global focus enforcer steals focus back; see FontPicker.tsx). React-
+  // state controlled + portaled to body like FontPicker's.
+  const [filterMenuOpen, setFilterMenuOpen] = useState(false);
+  const [filterMenuPos, setFilterMenuPos] = useState<{ left: number; top: number; width: number } | null>(null);
+  const filterTriggerRef = useRef<HTMLButtonElement>(null);
+
+  const toggleFilterMenu = () => {
+    if (filterMenuOpen) { setFilterMenuOpen(false); return; }
+    const r = filterTriggerRef.current?.getBoundingClientRect();
+    if (r) {
+      // Right-align to the trigger — the menu is wider than the button and
+      // the trigger hugs the rail's right edge.
+      const width = Math.max(r.width, 180);
+      setFilterMenuPos({ left: r.right - width, top: r.bottom + 4, width });
+    }
+    setFilterMenuOpen(true);
+  };
+
+  // Keep the portaled menu glued to the trigger on scroll/resize (it's
+  // fixed-positioned; same pattern as FontPicker).
+  useEffect(() => {
+    if (!filterMenuOpen) return;
+    const reposition = () => {
+      const r = filterTriggerRef.current?.getBoundingClientRect();
+      if (r) {
+        const width = Math.max(r.width, 180);
+        setFilterMenuPos({ left: r.right - width, top: r.bottom + 4, width });
+      }
+    };
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  }, [filterMenuOpen]);
   // Right-click cut/copy/paste/select menu for the search box (same one
   // Gambit/terminal/task-list use).
   const { menu: ctxMenuEl, openMenu: openCtxMenu } = useTextContextMenu();
@@ -131,6 +174,26 @@ export function HistoryBoard() {
     { id: 'mock-2', name: 'build a snake game', tool: 'claude', cwd: '~/projects/snake', session_token: 'tk2', saved_at: new Date(Date.now() - 3600000).toISOString() },
     { id: 'mock-3', name: 'refactor components', tool: 'qwen', cwd: '~/projects/coffee', session_token: 'tk3', saved_at: new Date(Date.now() - 86400000 * 2).toISOString() },
   ], [cachedSessions]);
+
+  // Chip data: per-tool session counts over the *visible* (unhidden) list,
+  // most-used first so the agent you reach for most often stays leftmost.
+  const toolCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const s of baseSessions) {
+      const tool = s.tool ?? '';
+      if (!tool || hidden.has(`${tool}:${s.id}`)) continue;
+      counts.set(tool, (counts.get(tool) ?? 0) + 1);
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  }, [baseSessions, hidden]);
+
+  // If the active tool vanishes from the data (e.g. all its sessions got
+  // hidden), fall back to "all" instead of staring at an empty list.
+  useEffect(() => {
+    if (activeTool && !toolCounts.some(([tool]) => tool === activeTool)) {
+      setActiveTool(null);
+    }
+  }, [toolCounts, activeTool]);
 
   // Debounce the raw query so fast typing doesn't re-filter the full session
   // list on every keystroke (history-cache can hold thousands of sessions —
@@ -146,10 +209,11 @@ export function HistoryBoard() {
   // normalization means "no query → show all". Matching against projectName(cwd)
   // too so a user can find a project's sessions by typing its folder name — the
   // folder is already printed on every card, so this is the one search
-  // dimension the flat time-sorted list genuinely earns. Both fields are
+  // dimension the flat time-sorted list genuinely earns. The tool display name
+  // is matched as well ("kimi" surfaces all Kimi Code sessions) — the chip row
+  // below covers mouse users, this covers keyboard users. All fields are
   // null-guarded: legacy sessions can carry a blank cwd (projectName then
-  // falls back to the tool display name, which is still a useful match — e.g.
-  // typing "claude" surfaces all Claude sessions).
+  // falls back to the tool display name).
   const matchedSessions = useMemo(() => {
     // Hide filter first so soft-deleted sessions never take a visible slot or
     // count toward load-more paging.
@@ -157,12 +221,17 @@ export function HistoryBoard() {
     if (hidden.size > 0) {
       list = list.filter(s => !hidden.has(`${s.tool ?? ''}:${s.id}`));
     }
+    // Agent chip filter (AND with the text query below).
+    if (activeTool) {
+      list = list.filter(s => (s.tool ?? '') === activeTool);
+    }
     const q = debouncedQuery.trim().replace(/\s+/g, ' ').toLowerCase();
     if (q) {
       list = list.filter(s => {
         const name = (s.name ?? '').toLowerCase();
         const proj = projectName(s.cwd ?? '', s.tool ?? '').toLowerCase();
-        return name.includes(q) || proj.includes(q);
+        const tool = getToolName(s.tool ?? '', '').toLowerCase();
+        return name.includes(q) || proj.includes(q) || tool.includes(q);
       });
     }
     // Pinned (置顶) sessions sort to the top. history-cache already returns
@@ -176,7 +245,7 @@ export function HistoryBoard() {
       });
     }
     return list;
-  }, [baseSessions, debouncedQuery, hidden, pinned]);
+  }, [baseSessions, debouncedQuery, hidden, pinned, activeTool]);
 
   // Progressive render: data is already fully in memory (history-cache reads
   // every jsonl on startup), so "load more" is just rendering more rows.
@@ -187,7 +256,7 @@ export function HistoryBoard() {
   // change.
   const PAGE = 30;
   const [visibleCount, setVisibleCount] = useState(PAGE);
-  useEffect(() => { setVisibleCount(PAGE); }, [debouncedQuery]);
+  useEffect(() => { setVisibleCount(PAGE); }, [debouncedQuery, activeTool]);
   const filteredSessions = matchedSessions.slice(0, visibleCount);
   const hasMore = matchedSessions.length > visibleCount;
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -225,19 +294,46 @@ export function HistoryBoard() {
 
   return (
     <>
-      <div className="agent-session-search-wrap">
-        <svg className="agent-session-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="11" cy="11" r="8"></circle>
-          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-        </svg>
-        <input 
-          type="text" 
-          className="agent-session-search" 
-          placeholder={t('task.search_sessions' as any) || 'Search sessions...'}
-          value={sessionSearchQuery}
-          onChange={e => setSessionSearchQuery(e.target.value)}
-          onContextMenu={(e) => openCtxMenu(e, setSessionSearchQuery)}
-        />
+      <div className="agent-session-search-row">
+        <div className="agent-session-search-wrap">
+          <svg className="agent-session-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+          <input
+            type="text"
+            className="agent-session-search"
+            placeholder={t('task.search_sessions' as any) || 'Search sessions...'}
+            value={sessionSearchQuery}
+            onChange={e => setSessionSearchQuery(e.target.value)}
+            onContextMenu={(e) => openCtxMenu(e, setSessionSearchQuery)}
+          />
+        </div>
+        {/* Agent filter dropdown — only worth the control when there's more
+            than one agent to tell apart. Shows the active agent's icon (or
+            全部), opens the portaled menu below. */}
+        {toolCounts.length >= 2 && (
+          <button
+            ref={filterTriggerRef}
+            type="button"
+            className={`history-tool-filter-trigger${activeTool ? ' active' : ''}`}
+            onClick={toggleFilterMenu}
+          >
+            {activeTool ? (
+              getToolIcon(activeTool)
+            ) : (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/>
+              </svg>
+            )}
+            <span className="history-tool-filter-label">
+              {activeTool ? getToolName(activeTool, '') : (t('task.filter_all' as any) || 'All')}
+            </span>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+        )}
       </div>
       <div className="task-list" style={{ marginTop: '0', paddingBottom: '20px' }}>
       {isLoading && Array.from({ length: 6 }).map((_, i) => (
@@ -345,6 +441,37 @@ export function HistoryBoard() {
         </div>
       )}
     </div>
+    {filterMenuOpen && filterMenuPos && createPortal(
+      <>
+        <div className="history-tool-filter-backdrop" onClick={() => setFilterMenuOpen(false)} />
+        <div
+          className="history-tool-filter-menu"
+          style={{ position: 'fixed', left: filterMenuPos.left, top: filterMenuPos.top, width: filterMenuPos.width }}
+        >
+          <button
+            type="button"
+            className={`history-tool-filter-opt${activeTool === null ? ' active' : ''}`}
+            onClick={() => { setActiveTool(null); setFilterMenuOpen(false); }}
+          >
+            <span className="history-tool-filter-opt-name">{t('task.filter_all' as any) || 'All'}</span>
+            <span className="history-tool-filter-count">{toolCounts.reduce((n, [, c]) => n + c, 0)}</span>
+          </button>
+          {toolCounts.map(([tool, count]) => (
+            <button
+              type="button"
+              key={tool}
+              className={`history-tool-filter-opt${activeTool === tool ? ' active' : ''}`}
+              onClick={() => { setActiveTool(activeTool === tool ? null : tool); setFilterMenuOpen(false); }}
+            >
+              {getToolIcon(tool)}
+              <span className="history-tool-filter-opt-name">{getToolName(tool, '')}</span>
+              <span className="history-tool-filter-count">{count}</span>
+            </button>
+          ))}
+        </div>
+      </>,
+      document.body
+    )}
     {ctxMenu && <SessionContextMenu menu={ctxMenu} onClose={() => setCtxMenu(null)} />}
     {ctxMenuEl}
   </>

--- a/src-ui/src/i18n/de.ts
+++ b/src-ui/src/i18n/de.ts
@@ -82,6 +82,7 @@ export const de = {
   'diff.unchanged_lines': '⋯ {count} unveränderte Zeilen',
   'task.default_title': 'Neue Aufgabe',
   'task.search_sessions': 'Sitzungen durchsuchen...',
+  'task.filter_all': 'Alle',
   'menu.no_recent': 'Keine aktuellen Sitzungen',
   'task.messages': '{count} Nachrichten',
 

--- a/src-ui/src/i18n/en.ts
+++ b/src-ui/src/i18n/en.ts
@@ -81,6 +81,7 @@ export const en = {
   'diff.unchanged_lines': '⋯ {count} unchanged lines',
   'task.default_title': 'New Task',
   'task.search_sessions': 'Search sessions...',
+  'task.filter_all': 'All',
   'menu.no_recent': 'No recent sessions found',
   'task.messages': '{count} messages',
 

--- a/src-ui/src/i18n/es.ts
+++ b/src-ui/src/i18n/es.ts
@@ -81,6 +81,7 @@ export const es = {
   'diff.unchanged_lines': '⋯ {count} líneas sin cambios',
   'task.default_title': 'Nueva tarea',
   'task.search_sessions': 'Buscar sesiones...',
+  'task.filter_all': 'Todos',
   'menu.no_recent': 'No hay sesiones recientes',
   'task.messages': '{count} mensajes',
 

--- a/src-ui/src/i18n/fr.ts
+++ b/src-ui/src/i18n/fr.ts
@@ -81,6 +81,7 @@ export const fr = {
   'diff.unchanged_lines': '⋯ {count} lignes inchangées',
   'task.default_title': 'Nouvelle tâche',
   'task.search_sessions': 'Rechercher des sessions...',
+  'task.filter_all': 'Tous',
   'menu.no_recent': 'Aucune session récente',
   'task.messages': '{count} messages',
 

--- a/src-ui/src/i18n/ja.ts
+++ b/src-ui/src/i18n/ja.ts
@@ -81,6 +81,7 @@ export const ja = {
   'diff.unchanged_lines': '⋯ 未変更 {count} 行',
   'task.default_title': '新しいタスク',
   'task.search_sessions': 'セッションを検索...',
+  'task.filter_all': 'すべて',
   'menu.no_recent': '最近のセッションはありません',
   'task.messages': 'メッセージ {count} 件',
 

--- a/src-ui/src/i18n/ko.ts
+++ b/src-ui/src/i18n/ko.ts
@@ -81,6 +81,7 @@ export const ko = {
   'diff.unchanged_lines': '⋯ 변경되지 않은 {count}줄',
   'task.default_title': '새 작업',
   'task.search_sessions': '세션 검색...',
+  'task.filter_all': '전부',
   'menu.no_recent': '최근 세션이 없습니다',
   'task.messages': '메시지 {count}개',
 

--- a/src-ui/src/i18n/pt.ts
+++ b/src-ui/src/i18n/pt.ts
@@ -82,6 +82,7 @@ export const pt = {
   'diff.unchanged_lines': '⋯ {count} linhas inalteradas',
   'task.default_title': 'Nova tarefa',
   'task.search_sessions': 'Buscar sessões...',
+  'task.filter_all': 'Todos',
   'menu.no_recent': 'Nenhuma sessão recente',
   'task.messages': '{count} mensagens',
 

--- a/src-ui/src/i18n/ru.ts
+++ b/src-ui/src/i18n/ru.ts
@@ -82,6 +82,7 @@ export const ru = {
   'diff.unchanged_lines': '⋯ {count} строк без изменений',
   'task.default_title': 'Новая задача',
   'task.search_sessions': 'Поиск сессий...',
+  'task.filter_all': 'Все',
   'menu.no_recent': 'Нет недавних сессий',
   'task.messages': '{count} сообщений',
 

--- a/src-ui/src/i18n/vi.ts
+++ b/src-ui/src/i18n/vi.ts
@@ -84,6 +84,7 @@ export const vi = {
   'diff.unchanged_lines': '⋯ {count} dòng không đổi',
   'task.default_title': 'Nhiệm vụ mới',
   'task.search_sessions': 'Tìm phiên làm việc...',
+  'task.filter_all': 'Tất cả',
   'menu.no_recent': 'Không tìm thấy phiên gần đây',
   'task.messages': '{count} tin nhắn',
 

--- a/src-ui/src/i18n/zh-CN.ts
+++ b/src-ui/src/i18n/zh-CN.ts
@@ -81,6 +81,7 @@ export const zhCN = {
   'diff.unchanged_lines': '⋯ {count} 行未改动',
   'task.default_title': '新任务',
   'task.search_sessions': '搜索历史对话...',
+  'task.filter_all': '全部',
   'menu.no_recent': '没有任何近期会话',
   'task.messages': '{count} 条消息',
 

--- a/src-ui/src/i18n/zh-TW.ts
+++ b/src-ui/src/i18n/zh-TW.ts
@@ -81,6 +81,7 @@ export const zhTW = {
   'diff.unchanged_lines': '⋯ {count} 行未變更',
   'task.default_title': '新任務',
   'task.search_sessions': '搜尋歷史對話...',
+  'task.filter_all': '全部',
   'menu.no_recent': '沒有任何近期對話',
   'task.messages': '{count} 則訊息',
 

--- a/src-ui/src/styles/global.css
+++ b/src-ui/src/styles/global.css
@@ -1706,6 +1706,7 @@ body.gambit-docked .multi-agent-grid-standalone {
    + outer drop shadow combo, so every floating overlay sits on
    the same Liquid-Glass tier above the panels. */
 [data-shape="glass"] .ctx-menu,
+[data-shape="glass"] .history-tool-filter-menu,
 [data-shape="glass"] .gambit-skill-popover {
     background: rgba(255, 255, 255, 0.06);
     border: 1px solid rgba(255, 255, 255, 0.14);


### PR DESCRIPTION
## 概述

会话记录面板把所有 agent 的会话混在一个按时间排序的扁平列表里。卡片上虽然有 agent 图标，但**无法按 agent 过滤**；搜索框也只匹配会话标题和项目文件夹名——「找出 Kimi 的所有会话」没有可靠路径（输入工具名只在 cwd 缺失时碰巧命中）。

本 PR 在搜索框旁加一个 **agent 筛选下拉**，并补齐搜索的工具名匹配。

## 交互

- 触发按钮在搜索框右侧，显示当前选中项（默认「全部」+ 漏斗图标；选中后变为该 agent 的图标+名称）
- 菜单列出「全部（总数）」+ 历史数据中实际出现的每个 agent（品牌图标 + 显示名 + 会话数，按数量降序），单选过滤、与文本搜索 AND 叠加、重选同一项取消
- **用 React-state + portal 的自绘菜单（FontPicker 同款模式），不用原生 `<select>`**——原生 select 无法主题化，且在终端持有焦点时根本打不开（全局 focus enforcer 会抢回焦点）
- 面板背景沿用 `.ctx-menu` 的不透明处理（`--bg-panel` 叠 `--bg-app`，glass 主题走 global.css 的磨砂覆盖）——`--bg-card` 在深色主题下是 3% 白，浮层直接用会透明（第一版实测踩坑）

## 细节

- **只在 ≥2 种 agent 时渲染**（只有一种来源时筛选无意义）
- 计数统计自隐藏（soft-delete）过滤后的数据，与列表始终一致
- 选中的 agent 从数据里消失时（如会话全被隐藏）自动回到「全部」，不留给用户看不懂的空列表
- 文本搜索新增工具显示名匹配：输入 `kimi` 直接命中所有 Kimi Code 会话（下拉服务鼠标用户，这个服务键盘用户）
- 与置顶排序、隐藏、右键菜单全部兼容；分页随筛选切换重置
- i18n：新增 `task.filter_all`，11 个语言全部补齐

## 验证

- `npm run build`（tsc + vite）绿
- Windows 11 实机验证（深色主题）：下拉渲染、点选过滤、重选取消、叠加文字搜索、置顶/隐藏右键菜单不回归
