### PR TITLE
feat(history): 工作目录筛选下拉 + 会话重命名 + 卡片一键置顶

### DIFF
--- a/src-ui/src/components/right/HistoryBoard.css
+++ b/src-ui/src/components/right/HistoryBoard.css
@@ -6,6 +6,7 @@
    contrast. */
 
 .history-card {
+  position: relative;
   padding: 14px 14px;
   margin-bottom: 8px;
   cursor: default !important;
@@ -55,13 +56,6 @@
    shown only on pinned cards. Non-interactive (pin/unpin lives in the right-
    click context menu); styled to match the meta row text so it reads as an
    indicator, not a button. No hover/cursor - pure marker. */
-.history-card-pin {
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  color: var(--text-3);
-  opacity: 0.7;
-}
 /* ── Loading Skeleton ──
    Shimmer driven by --text-3 so the skeleton bars are visible against
    light AND dark cards. Pure white-rgba was invisible on the light theme. */
@@ -134,4 +128,146 @@
 .agent-session-search:focus {
   background: var(--bg-hover);
   border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+}
+
+/* ─── Agent filter dropdown ─── */
+/* Search row: the input takes the remaining width, the filter trigger hugs
+   the right edge. */
+.agent-session-search-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.agent-session-search-row .agent-session-search-wrap {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+.history-tool-filter-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-2);
+  font-size: 12px;
+  font-family: var(--font, system-ui);
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.history-tool-filter-trigger:hover {
+  background: var(--bg-hover);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+}
+.history-tool-filter-trigger.active {
+  border-color: var(--accent);
+  color: var(--text-1);
+}
+.history-tool-filter-label {
+  max-width: 72px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.history-tool-filter-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+.history-tool-filter-menu {
+  /* Same opacity fix as Explorer's .ctx-menu — --bg-card is ~3% white in
+     dark themes, so a portaled menu floating over the session list reads
+     as transparent. Layer --bg-panel over --bg-app so Light theme's
+     translucent panel still reads opaque. Glass shape gets its frosted
+     look from the [data-shape="glass"] override in global.css. */
+  background-color: var(--bg-app);
+  background-image: linear-gradient(var(--bg-panel), var(--bg-panel));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.20), 0 6px 20px rgba(0, 0, 0, 0.22);
+  padding: 4px;
+  z-index: 1000;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.history-tool-filter-opt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-xs);
+  color: var(--text-1);
+  font-size: 12.5px;
+  font-family: var(--font, system-ui);
+  text-align: left;
+  cursor: pointer;
+}
+.history-tool-filter-opt:hover {
+  background: var(--bg-hover);
+}
+.history-tool-filter-opt.active {
+  color: var(--accent);
+}
+.history-tool-filter-opt-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.history-tool-filter-count {
+  color: var(--text-3);
+  font-size: 11px;
+}
+
+/* ─── Card pin button + inline rename ─── */
+/* One-click pin at the card's top-right. Hidden until hover; always shown
+   (accent, filled) once pinned — it doubles as the pinned marker. */
+.history-card-pin-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-xs);
+  color: var(--text-3);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.history-card:hover .history-card-pin-btn,
+.history-card-pin-btn.pinned {
+  opacity: 1;
+}
+.history-card-pin-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-1);
+}
+.history-card-pin-btn.pinned {
+  color: var(--accent);
+}
+
+.history-card-rename-input {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg-app);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-xs);
+  padding: 2px 6px;
+  color: var(--text-1);
+  font-size: 13px;
+  font-family: var(--font, system-ui);
+  outline: none;
 }

--- a/src-ui/src/components/right/HistoryBoard.tsx
+++ b/src-ui/src/components/right/HistoryBoard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
 import { useT } from '../../i18n/useT';
 import { useAppState } from '../../store/app-state';
 import { isTauri } from '../../tauri';
@@ -10,7 +11,8 @@ import {
   getHistorySnapshot,
 } from '../../lib/history-cache';
 import { subscribeHidden, getHiddenSnapshot } from '../../lib/hidden-sessions';
-import { subscribePinned, getPinnedSnapshot } from '../../lib/pinned-sessions';
+import { subscribePinned, getPinnedSnapshot, togglePin } from '../../lib/pinned-sessions';
+import { subscribeRenamed, getRenamedSnapshot, setCustomName } from '../../lib/renamed-sessions';
 import { SessionContextMenu, type SessionCtxMenuState } from './SessionContextMenu';
 import { useTextContextMenu } from '../../lib/use-text-context-menu';
 // hermes/opencode PNG assets live in src/icons-inline/ so the Launchpad
@@ -95,6 +97,17 @@ const projectName = (cwd: string, tool: string) => {
   return getToolName(tool, '');
 };
 
+// Normalize a recorded cwd for grouping: trim trailing slashes and unify
+// separators. Deliberately NOT case-folded — Linux paths are case-sensitive.
+const normCwd = (cwd: string) => cwd.replace(/[\\/]+$/, '').replace(/\//g, '\\');
+
+// Last path segment of either separator flavor.
+const pathBasename = (p: string) => {
+  const trimmed = p.replace(/[\\/]+$/, '');
+  const idx = Math.max(trimmed.lastIndexOf('\\'), trimmed.lastIndexOf('/'));
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+};
+
 export function HistoryBoard() {
   const t = useT();
   const { state, dispatch } = useAppState();
@@ -113,11 +126,60 @@ export function HistoryBoard() {
   // Pinned (置顶) markers from localStorage - re-renders + re-sorts the list
   // the instant a pin toggles from the context menu.
   const pinned = useSyncExternalStore(subscribePinned, getPinnedSnapshot);
+  // Custom session titles from localStorage (rename feature) - re-renders
+  // the list the instant a rename lands.
+  const renamed = useSyncExternalStore(subscribeRenamed, getRenamedSnapshot);
+  // Inline-rename editing state: which card is being renamed (`${tool}:${id}`
+  // key, null = none) and the draft value.
+  const [renamingKey, setRenamingKey] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
   const [ctxMenu, setCtxMenu] = useState<SessionCtxMenuState | null>(null);
   useEffect(() => { prefetchHistory(); }, []);
   const isLoading = isTauri && (status === 'idle' || status === 'loading') && cachedSessions.length === 0;
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
+  // Project (workspace) filter dropdown: which cwd's sessions to show
+  // (null = all). The option list is derived from the *visible* (unhidden)
+  // data so its counts always match what the list would show.
+  const [activeProject, setActiveProject] = useState<string | null>(null);
+  // The filter is a themed dropdown (NOT a native <select> — that can't be
+  // themed, and can't even open while a terminal is active because the
+  // global focus enforcer steals focus back; see FontPicker.tsx). React-
+  // state controlled + portaled to body like FontPicker's.
+  const [filterMenuOpen, setFilterMenuOpen] = useState(false);
+  const [filterMenuPos, setFilterMenuPos] = useState<{ left: number; top: number; width: number } | null>(null);
+  const filterTriggerRef = useRef<HTMLButtonElement>(null);
+
+  const toggleFilterMenu = () => {
+    if (filterMenuOpen) { setFilterMenuOpen(false); return; }
+    const r = filterTriggerRef.current?.getBoundingClientRect();
+    if (r) {
+      // Right-align to the trigger — the menu is wider than the button and
+      // the trigger hugs the rail's right edge.
+      const width = Math.max(r.width, 180);
+      setFilterMenuPos({ left: r.right - width, top: r.bottom + 4, width });
+    }
+    setFilterMenuOpen(true);
+  };
+
+  // Keep the portaled menu glued to its trigger on scroll/resize (it's
+  // fixed-positioned; same pattern as FontPicker).
+  useEffect(() => {
+    if (!filterMenuOpen) return;
+    const reposition = () => {
+      const r = filterTriggerRef.current?.getBoundingClientRect();
+      if (r) {
+        const width = Math.max(r.width, 180);
+        setFilterMenuPos({ left: r.right - width, top: r.bottom + 4, width });
+      }
+    };
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  }, [filterMenuOpen]);
   // Right-click cut/copy/paste/select menu for the search box (same one
   // Gambit/terminal/task-list use).
   const { menu: ctxMenuEl, openMenu: openCtxMenu } = useTextContextMenu();
@@ -131,6 +193,48 @@ export function HistoryBoard() {
     { id: 'mock-2', name: 'build a snake game', tool: 'claude', cwd: '~/projects/snake', session_token: 'tk2', saved_at: new Date(Date.now() - 3600000).toISOString() },
     { id: 'mock-3', name: 'refactor components', tool: 'qwen', cwd: '~/projects/coffee', session_token: 'tk3', saved_at: new Date(Date.now() - 86400000 * 2).toISOString() },
   ], [cachedSessions]);
+
+  // Project (workspace) filter: which cwd's sessions to show (null = all).
+  // Keyed by normalized cwd (trailing slashes trimmed, separators unified —
+  // no case-folding: Linux paths are case-sensitive).
+  const projectCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    // Display form of each normalized key: first-seen original cwd wins.
+    const display = new Map<string, string>();
+    for (const s of baseSessions) {
+      const raw = (s.cwd ?? '').trim();
+      if (!raw || hidden.has(`${s.tool ?? ''}:${s.id}`)) continue;
+      const key = normCwd(raw);
+      if (!display.has(key)) display.set(key, raw.replace(/[\\/]+$/, ''));
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .map(([key, count]) => ({ key, cwd: display.get(key)!, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [baseSessions, hidden]);
+
+  // Basename collisions (two different parents both named "coffee") get the
+  // parent dir appended in the menu label so they're tellable apart.
+  const projectLabel = useMemo(() => {
+    const baseCount = new Map<string, number>();
+    for (const p of projectCounts) {
+      const base = pathBasename(p.cwd);
+      baseCount.set(base, (baseCount.get(base) ?? 0) + 1);
+    }
+    return (cwd: string): string => {
+      const base = pathBasename(cwd);
+      if ((baseCount.get(base) ?? 0) <= 1) return base;
+      const parent = pathBasename(cwd.slice(0, cwd.length - base.length).replace(/[\\/]+$/, ''));
+      return parent ? `${base} — ${parent}` : base;
+    };
+  }, [projectCounts]);
+
+  // Same auto-reset discipline as the agent filter.
+  useEffect(() => {
+    if (activeProject && !projectCounts.some(p => p.key === activeProject)) {
+      setActiveProject(null);
+    }
+  }, [projectCounts, activeProject]);
 
   // Debounce the raw query so fast typing doesn't re-filter the full session
   // list on every keystroke (history-cache can hold thousands of sessions —
@@ -146,10 +250,11 @@ export function HistoryBoard() {
   // normalization means "no query → show all". Matching against projectName(cwd)
   // too so a user can find a project's sessions by typing its folder name — the
   // folder is already printed on every card, so this is the one search
-  // dimension the flat time-sorted list genuinely earns. Both fields are
+  // dimension the flat time-sorted list genuinely earns. The tool display name
+  // is matched as well ("kimi" surfaces all Kimi Code sessions) — the chip row
+  // below covers mouse users, this covers keyboard users. All fields are
   // null-guarded: legacy sessions can carry a blank cwd (projectName then
-  // falls back to the tool display name, which is still a useful match — e.g.
-  // typing "claude" surfaces all Claude sessions).
+  // falls back to the tool display name).
   const matchedSessions = useMemo(() => {
     // Hide filter first so soft-deleted sessions never take a visible slot or
     // count toward load-more paging.
@@ -157,12 +262,17 @@ export function HistoryBoard() {
     if (hidden.size > 0) {
       list = list.filter(s => !hidden.has(`${s.tool ?? ''}:${s.id}`));
     }
+    // Project (cwd) filter — AND semantics with the text query below.
+    if (activeProject) {
+      list = list.filter(s => !!s.cwd && normCwd(s.cwd) === activeProject);
+    }
     const q = debouncedQuery.trim().replace(/\s+/g, ' ').toLowerCase();
     if (q) {
       list = list.filter(s => {
-        const name = (s.name ?? '').toLowerCase();
+        const name = (renamed[`${s.tool ?? ''}:${s.id}`] ?? s.name ?? '').toLowerCase();
         const proj = projectName(s.cwd ?? '', s.tool ?? '').toLowerCase();
-        return name.includes(q) || proj.includes(q);
+        const tool = getToolName(s.tool ?? '', '').toLowerCase();
+        return name.includes(q) || proj.includes(q) || tool.includes(q);
       });
     }
     // Pinned (置顶) sessions sort to the top. history-cache already returns
@@ -176,7 +286,7 @@ export function HistoryBoard() {
       });
     }
     return list;
-  }, [baseSessions, debouncedQuery, hidden, pinned]);
+  }, [baseSessions, debouncedQuery, hidden, pinned, activeProject, renamed]);
 
   // Progressive render: data is already fully in memory (history-cache reads
   // every jsonl on startup), so "load more" is just rendering more rows.
@@ -187,7 +297,7 @@ export function HistoryBoard() {
   // change.
   const PAGE = 30;
   const [visibleCount, setVisibleCount] = useState(PAGE);
-  useEffect(() => { setVisibleCount(PAGE); }, [debouncedQuery]);
+  useEffect(() => { setVisibleCount(PAGE); }, [debouncedQuery, activeProject]);
   const filteredSessions = matchedSessions.slice(0, visibleCount);
   const hasMore = matchedSessions.length > visibleCount;
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -203,6 +313,13 @@ export function HistoryBoard() {
     io.observe(el);
     return () => io.disconnect();
   }, [hasMore]);
+
+  // Enter inline-rename mode on a card (invoked from the context menu).
+  const startRename = (saved: SavedSession) => {
+    const k = `${saved.tool ?? ''}:${saved.id}`;
+    setRenamingKey(k);
+    setRenameValue(renamed[k] ?? saved.name ?? '');
+  };
 
   const handleViewHistory = (saved: SavedSession) => {
     // Click = resume directly. The old flow opened a ChatReader tab (read-
@@ -225,19 +342,45 @@ export function HistoryBoard() {
 
   return (
     <>
-      <div className="agent-session-search-wrap">
-        <svg className="agent-session-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="11" cy="11" r="8"></circle>
-          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-        </svg>
-        <input 
-          type="text" 
-          className="agent-session-search" 
-          placeholder={t('task.search_sessions' as any) || 'Search sessions...'}
-          value={sessionSearchQuery}
-          onChange={e => setSessionSearchQuery(e.target.value)}
-          onContextMenu={(e) => openCtxMenu(e, setSessionSearchQuery)}
-        />
+      <div className="agent-session-search-row">
+        <div className="agent-session-search-wrap">
+          <svg className="agent-session-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+          <input
+            type="text"
+            className="agent-session-search"
+            placeholder={t('task.search_sessions' as any) || 'Search sessions...'}
+            value={sessionSearchQuery}
+            onChange={e => setSessionSearchQuery(e.target.value)}
+            onContextMenu={(e) => openCtxMenu(e, setSessionSearchQuery)}
+          />
+        </div>
+        {/* Project (workspace) filter dropdown, keyed by normalized cwd.
+            Only worth the control when 2+ distinct projects exist. Shows the
+            active project's folder icon + name (full path in tooltip). */}
+        {projectCounts.length >= 2 && (
+          <button
+            ref={filterTriggerRef}
+            type="button"
+            className={`history-tool-filter-trigger${activeProject ? ' active' : ''}`}
+            onClick={toggleFilterMenu}
+            title={activeProject ? (projectCounts.find(p => p.key === activeProject)?.cwd ?? '') : undefined}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+            </svg>
+            <span className="history-tool-filter-label">
+              {activeProject
+                ? projectLabel(projectCounts.find(p => p.key === activeProject)?.cwd ?? '')
+                : (t('task.filter_all_projects' as any) || 'All projects')}
+            </span>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+        )}
       </div>
       <div className="task-list" style={{ marginTop: '0', paddingBottom: '20px' }}>
       {isLoading && Array.from({ length: 6 }).map((_, i) => (
@@ -284,7 +427,10 @@ export function HistoryBoard() {
           }
         }
 
-        const isPinnedSession = pinned.has(`${session.tool ?? ''}:${session.id}`);
+        const sessionKey = `${session.tool ?? ''}:${session.id}`;
+        const isPinnedSession = pinned.has(sessionKey);
+        const displayName = renamed[sessionKey] ?? session.name;
+        const isRenaming = renamingKey === sessionKey;
         return (
           <div
             key={session.id}
@@ -297,22 +443,57 @@ export function HistoryBoard() {
             }}
           >
             <div className="history-card-content">
-              <span className="history-card-title">{session.name}</span>
+              {isRenaming ? (
+                <input
+                  className="history-card-rename-input"
+                  autoFocus
+                  value={renameValue}
+                  onChange={(e) => setRenameValue(e.target.value)}
+                  // Keep the card's click-to-resume and right-click menu off
+                  // the editing field.
+                  onClick={(e) => e.stopPropagation()}
+                  onContextMenu={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      setCustomName(session.tool ?? '', session.id, renameValue);
+                      setRenamingKey(null);
+                    } else if (e.key === 'Escape') {
+                      setRenamingKey(null);
+                    }
+                  }}
+                  onBlur={() => {
+                    setCustomName(session.tool ?? '', session.id, renameValue);
+                    setRenamingKey(null);
+                  }}
+                  onFocus={(e) => e.target.select()}
+                />
+              ) : (
+                <span className="history-card-title">{displayName}</span>
+              )}
               <div className="history-card-meta">
                 <span className="history-card-tool-wrap">
                   {getToolIcon(session.tool)}
-                  <span>{projectName(session.cwd, session.tool)} &middot; {dateStr} {session.turn_count ? ` \u00B7 ${(t('task.messages' as any) || '{count} messages').replace('{count}', session.turn_count.toString())}` : ''}</span>
+                  <span>{projectName(session.cwd, session.tool)} &middot; {dateStr} {session.turn_count ? ` · ${(t('task.messages' as any) || '{count} messages').replace('{count}', session.turn_count.toString())}` : ''}</span>
                 </span>
-                {isPinnedSession && (
-                  <span className="history-card-pin" aria-hidden="true">
-                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M12 17v5"/>
-                      <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/>
-                    </svg>
-                  </span>
-                )}
               </div>
             </div>
+            {/* One-click pin, hover-revealed (always visible once pinned,
+                replacing the old passive marker). stopPropagation so it
+                doesn't trigger the card's click-to-resume. */}
+            <button
+              type="button"
+              className={`history-card-pin-btn${isPinnedSession ? ' pinned' : ''}`}
+              title={isPinnedSession ? t('menu.unpin' as any) : t('menu.pin' as any)}
+              onClick={(e) => {
+                e.stopPropagation();
+                togglePin(session.tool ?? '', session.id);
+              }}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill={isPinnedSession ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 17v5"/>
+                <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/>
+              </svg>
+            </button>
           </div>
         );
       })}
@@ -345,7 +526,41 @@ export function HistoryBoard() {
         </div>
       )}
     </div>
-    {ctxMenu && <SessionContextMenu menu={ctxMenu} onClose={() => setCtxMenu(null)} />}
+    {filterMenuOpen && filterMenuPos && createPortal(
+      <>
+        <div className="history-tool-filter-backdrop" onClick={() => setFilterMenuOpen(false)} />
+        <div
+          className="history-tool-filter-menu"
+          style={{ position: 'fixed', left: filterMenuPos.left, top: filterMenuPos.top, width: filterMenuPos.width }}
+        >
+          <button
+            type="button"
+            className={`history-tool-filter-opt${activeProject === null ? ' active' : ''}`}
+            onClick={() => { setActiveProject(null); setFilterMenuOpen(false); }}
+          >
+            <span className="history-tool-filter-opt-name">{t('task.filter_all_projects' as any) || 'All projects'}</span>
+            <span className="history-tool-filter-count">{baseSessions.reduce((n, s) => (hidden.has(`${s.tool ?? ''}:${s.id}`) ? n : n + 1), 0)}</span>
+          </button>
+          {projectCounts.map((p) => (
+            <button
+              type="button"
+              key={p.key}
+              className={`history-tool-filter-opt${activeProject === p.key ? ' active' : ''}`}
+              title={p.cwd}
+              onClick={() => { setActiveProject(activeProject === p.key ? null : p.key); setFilterMenuOpen(false); }}
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+                <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+              </svg>
+              <span className="history-tool-filter-opt-name">{projectLabel(p.cwd)}</span>
+              <span className="history-tool-filter-count">{p.count}</span>
+            </button>
+          ))}
+        </div>
+      </>,
+      document.body
+    )}
+    {ctxMenu && <SessionContextMenu menu={ctxMenu} onClose={() => setCtxMenu(null)} onRename={startRename} />}
     {ctxMenuEl}
   </>
   );

--- a/src-ui/src/components/right/SessionContextMenu.tsx
+++ b/src-ui/src/components/right/SessionContextMenu.tsx
@@ -35,7 +35,7 @@ const ICON_PROPS = {
   strokeLinejoin: 'round' as const,
 };
 
-export function SessionContextMenu({ menu, onClose }: { menu: SessionCtxMenuState; onClose: () => void }) {
+export function SessionContextMenu({ menu, onClose, onRename }: { menu: SessionCtxMenuState; onClose: () => void; onRename: (session: SavedSession) => void }) {
   const t = useT();
   const menuRef = useRef<HTMLDivElement>(null);
   const { session } = menu;
@@ -65,6 +65,7 @@ export function SessionContextMenu({ menu, onClose }: { menu: SessionCtxMenuStat
 
   const copy = (text: string) => { clipboardWrite(text); onClose(); };
   const handlePin = () => { togglePin(session.tool ?? '', session.id); onClose(); };
+  const handleRename = () => { onRename(session); onClose(); };
   const handleDelete = () => { hideSession(session.tool ?? '', session.id); onClose(); };
   const handleShowInFolder = async () => {
     onClose();
@@ -74,7 +75,7 @@ export function SessionContextMenu({ menu, onClose }: { menu: SessionCtxMenuStat
 
   // Smart positioning - mirror Explorer's ContextMenu (overflow flip).
   const MENU_WIDTH = 220;
-  const MENU_HEIGHT = 260;
+  const MENU_HEIGHT = 290;
   const isBottomOverflow = menu.y + MENU_HEIGHT > window.innerHeight;
   const isRightOverflow = menu.x + MENU_WIDTH > window.innerWidth;
   const style: React.CSSProperties = {
@@ -91,6 +92,13 @@ export function SessionContextMenu({ menu, onClose }: { menu: SessionCtxMenuStat
           <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/>
         </svg>
         {pinned ? t('menu.unpin' as any) : t('menu.pin' as any)}
+      </button>
+
+      <button className="ctx-menu-item" onClick={handleRename}>
+        <svg {...ICON_PROPS}>
+          <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
+        </svg>
+        {t('menu.rename' as any)}
       </button>
 
       {hasGroup2 && <div className="ctx-menu-divider" />}

--- a/src-ui/src/i18n/de.ts
+++ b/src-ui/src/i18n/de.ts
@@ -82,6 +82,7 @@ export const de = {
   'diff.unchanged_lines': '⋯ {count} unveränderte Zeilen',
   'task.default_title': 'Neue Aufgabe',
   'task.search_sessions': 'Sitzungen durchsuchen...',
+  'task.filter_all_projects': 'Alle Projekte',
   'menu.no_recent': 'Keine aktuellen Sitzungen',
   'task.messages': '{count} Nachrichten',
 

--- a/src-ui/src/i18n/en.ts
+++ b/src-ui/src/i18n/en.ts
@@ -81,6 +81,7 @@ export const en = {
   'diff.unchanged_lines': '⋯ {count} unchanged lines',
   'task.default_title': 'New Task',
   'task.search_sessions': 'Search sessions...',
+  'task.filter_all_projects': 'All projects',
   'menu.no_recent': 'No recent sessions found',
   'task.messages': '{count} messages',
 

--- a/src-ui/src/i18n/es.ts
+++ b/src-ui/src/i18n/es.ts
@@ -81,6 +81,7 @@ export const es = {
   'diff.unchanged_lines': '⋯ {count} líneas sin cambios',
   'task.default_title': 'Nueva tarea',
   'task.search_sessions': 'Buscar sesiones...',
+  'task.filter_all_projects': 'Todos los proyectos',
   'menu.no_recent': 'No hay sesiones recientes',
   'task.messages': '{count} mensajes',
 

--- a/src-ui/src/i18n/fr.ts
+++ b/src-ui/src/i18n/fr.ts
@@ -81,6 +81,7 @@ export const fr = {
   'diff.unchanged_lines': '⋯ {count} lignes inchangées',
   'task.default_title': 'Nouvelle tâche',
   'task.search_sessions': 'Rechercher des sessions...',
+  'task.filter_all_projects': 'Tous les projets',
   'menu.no_recent': 'Aucune session récente',
   'task.messages': '{count} messages',
 

--- a/src-ui/src/i18n/ja.ts
+++ b/src-ui/src/i18n/ja.ts
@@ -81,6 +81,7 @@ export const ja = {
   'diff.unchanged_lines': '⋯ 未変更 {count} 行',
   'task.default_title': '新しいタスク',
   'task.search_sessions': 'セッションを検索...',
+  'task.filter_all_projects': 'すべてのプロジェクト',
   'menu.no_recent': '最近のセッションはありません',
   'task.messages': 'メッセージ {count} 件',
 

--- a/src-ui/src/i18n/ko.ts
+++ b/src-ui/src/i18n/ko.ts
@@ -81,6 +81,7 @@ export const ko = {
   'diff.unchanged_lines': '⋯ 변경되지 않은 {count}줄',
   'task.default_title': '새 작업',
   'task.search_sessions': '세션 검색...',
+  'task.filter_all_projects': '모든 프로젝트',
   'menu.no_recent': '최근 세션이 없습니다',
   'task.messages': '메시지 {count}개',
 

--- a/src-ui/src/i18n/pt.ts
+++ b/src-ui/src/i18n/pt.ts
@@ -82,6 +82,7 @@ export const pt = {
   'diff.unchanged_lines': '⋯ {count} linhas inalteradas',
   'task.default_title': 'Nova tarefa',
   'task.search_sessions': 'Buscar sessões...',
+  'task.filter_all_projects': 'Todos os projetos',
   'menu.no_recent': 'Nenhuma sessão recente',
   'task.messages': '{count} mensagens',
 

--- a/src-ui/src/i18n/ru.ts
+++ b/src-ui/src/i18n/ru.ts
@@ -82,6 +82,7 @@ export const ru = {
   'diff.unchanged_lines': '⋯ {count} строк без изменений',
   'task.default_title': 'Новая задача',
   'task.search_sessions': 'Поиск сессий...',
+  'task.filter_all_projects': 'Все проекты',
   'menu.no_recent': 'Нет недавних сессий',
   'task.messages': '{count} сообщений',
 

--- a/src-ui/src/i18n/vi.ts
+++ b/src-ui/src/i18n/vi.ts
@@ -84,6 +84,7 @@ export const vi = {
   'diff.unchanged_lines': '⋯ {count} dòng không đổi',
   'task.default_title': 'Nhiệm vụ mới',
   'task.search_sessions': 'Tìm phiên làm việc...',
+  'task.filter_all_projects': 'Tất cả dự án',
   'menu.no_recent': 'Không tìm thấy phiên gần đây',
   'task.messages': '{count} tin nhắn',
 

--- a/src-ui/src/i18n/zh-CN.ts
+++ b/src-ui/src/i18n/zh-CN.ts
@@ -81,6 +81,7 @@ export const zhCN = {
   'diff.unchanged_lines': '⋯ {count} 行未改动',
   'task.default_title': '新任务',
   'task.search_sessions': '搜索历史对话...',
+  'task.filter_all_projects': '全部项目',
   'menu.no_recent': '没有任何近期会话',
   'task.messages': '{count} 条消息',
 

--- a/src-ui/src/i18n/zh-TW.ts
+++ b/src-ui/src/i18n/zh-TW.ts
@@ -81,6 +81,7 @@ export const zhTW = {
   'diff.unchanged_lines': '⋯ {count} 行未變更',
   'task.default_title': '新任務',
   'task.search_sessions': '搜尋歷史對話...',
+  'task.filter_all_projects': '全部專案',
   'menu.no_recent': '沒有任何近期對話',
   'task.messages': '{count} 則訊息',
 

--- a/src-ui/src/lib/renamed-sessions.ts
+++ b/src-ui/src/lib/renamed-sessions.ts
@@ -1,0 +1,85 @@
+// Renamed sessions - localStorage-backed custom title table.
+//
+// Same local-marker design as pinned-sessions.ts / hidden-sessions.ts:
+// Coffee only *reads* each CLI tool's session data for the 会话记录 list,
+// so a rename is a per-device override layered on top of the tool's own
+// auto-generated title — never a write into the tool's session files
+// (those formats are per-tool and risky to mutate). Keyed `${tool}:${id}`
+// like the other two tables. HistoryBoard renders the custom name when
+// present, falls back to the auto title otherwise; search matches the
+// displayed (custom) name.
+//
+// External-store shape mirrors pinned-sessions.ts so HistoryBoard
+// subscribes via useSyncExternalStore and re-renders the instant a rename
+// lands.
+
+const STORAGE_KEY = 'coffee:renamed-sessions';
+
+let names: Record<string, string> = load();
+const listeners = new Set<() => void>();
+
+function load(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const obj = JSON.parse(raw);
+    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return {};
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (typeof v === 'string' && v.trim()) out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function persist(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(names));
+  } catch {
+    // quota exceeded / localStorage disabled - rename stays in-memory for this session
+  }
+}
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+function key(tool: string, id: string): string {
+  return `${tool}:${id}`;
+}
+
+export function getCustomName(tool: string, id: string): string | undefined {
+  return names[key(tool, id)];
+}
+
+/** Set (or replace) a custom title. Empty / whitespace-only clears the
+ *  override, reverting the card to the tool's auto title. */
+export function setCustomName(tool: string, id: string, name: string | null): void {
+  const k = key(tool, id);
+  const trimmed = (name ?? '').trim();
+  if (trimmed) {
+    if (names[k] === trimmed) return;
+    names = { ...names, [k]: trimmed };
+  } else {
+    if (!(k in names)) return;
+    const next = { ...names };
+    delete next[k];
+    names = next;
+  }
+  persist();
+  emit();
+}
+
+/** useSyncExternalStore subscribe. */
+export function subscribeRenamed(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+/** useSyncExternalStore getSnapshot. Returns a stable reference that only
+ *  swaps when a rename lands (immutable update), so React doesn't loop. */
+export function getRenamedSnapshot(): Record<string, string> {
+  return names;
+}

--- a/src-ui/src/styles/global.css
+++ b/src-ui/src/styles/global.css
@@ -1706,6 +1706,7 @@ body.gambit-docked .multi-agent-grid-standalone {
    + outer drop shadow combo, so every floating overlay sits on
    the same Liquid-Glass tier above the panels. */
 [data-shape="glass"] .ctx-menu,
+[data-shape="glass"] .history-tool-filter-menu,
 [data-shape="glass"] .gambit-skill-popover {
     background: rgba(255, 255, 255, 0.06);
     border: 1px solid rgba(255, 255, 255, 0.14);


### PR DESCRIPTION
## 概述

接 #99 的讨论：按「工作目录」这个主轴重做——这次提的是三个围绕**回到工作场景**的改进，不含 agent 筛选。

## 1. 工作目录筛选下拉

会话卡片都带 cwd，但面板没有按它过滤的入口。搜索框旁新增下拉（文件夹图标）：

- 列出历史中实际出现的每个项目文件夹：basename + 会话数，按数量降序
- 重名项目（不同父目录同名）自动追加父目录区分，完整路径在 tooltip
- 单选过滤，与文字搜索 AND 叠加；重选同一项取消
- 配合现有的「点卡片直接恢复会话」：**选项目 → 看到该项目全部会话 → 点一条回到那个工作场景**
- 无 cwd 记录的老会话只在「全部项目」出现；≥2 个项目才渲染该控件

交互沿用 FontPicker 的 React-state + portal 模式（原生 `<select>` 无法主题化、终端持焦时打不开）；不透明背景复用 `.ctx-menu` 的分层处理，glass 主题走 global.css 的磨砂覆盖。

## 2. 会话重命名

自动标题（首条提问摘要）经常词不达意。右键菜单新增「重命名」：标题变内联输入框，Enter/失焦保存、Esc 取消、**清空保存=恢复自动标题**。

自定义名存 localStorage（新增 `lib/renamed-sessions.ts`，与 pinned/hidden 同一套本机标记设计——**不写回各 CLI 的会话文件**），显示覆盖自动标题、搜索可命中。

## 3. 卡片一键置顶按钮

置顶功能原本只藏在右键菜单里。卡片悬停显示图钉按钮，一键置顶/取消；置顶后常显实心图钉（兼作标记，替换原来的被动标记）。

## 验证

- `npm run build`（tsc + vite）绿
- Windows 11 实机验证：下拉渲染（图标/计数/高亮）、点选过滤、重选取消、与搜索/置顶/隐藏叠加、重命名内联编辑全流程
- i18n：`menu.rename` 复用现有 key；新增 `task.filter_all_projects`，11 语言补齐
