### PR TITLE
feat(launch): 外部唤起子命令 + macOS 标题栏红绿灯与 logo 布局修复 (closes #102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,28 @@ The Coffee CLI app ships with a fully localized UI in 11 languages — menus, di
 | **Task Board** | Organize what you've asked the agent to do across To-Do / In Progress / Done |
 | **Agent Installer** | One-click install of Claude Code, Codex, and more — no terminal required |
 | **Remote Terminal** | SSH into remote machines and run agents on servers without leaving the app |
+| **External Launch** | Open the app straight into a fresh agent tab at a chosen folder from scripts, launchers, and file-manager context menus |
 
 **11 languages supported out of the box:** English · 简体中文 · 繁體中文 · Deutsch · Español · Français · 日本語 · 한국어 · Português · Русский · Tiếng Việt
+
+### External Launch (CLI)
+
+`coffee-cli launch --tool <id> [--cwd <dir>]` skips the launchpad and drops
+you straight into a new agent tab — for launcher apps, context menus,
+Raycast/Alfred actions, and shell aliases. `--tool` is any registered tool
+id (`claude`, `codex`, `kimicode`, `hermes`, …); omit `--cwd` to reuse the
+tool's last folder. Already running? The request is forwarded to the
+running instance and opens a new tab — existing sessions are never
+restarted or hijacked.
+
+```bash
+# macOS — call the binary directly (LaunchServices drops --args when the app is already running)
+"/Applications/Coffee CLI.app/Contents/MacOS/coffee-cli" launch --tool kimicode --cwd /work/project
+# Windows — pair with an Explorer right-click entry that passes the folder as %V
+coffee-cli.exe launch --tool claude --cwd "C:\work\project"
+# Linux
+coffee-cli launch --tool codex --cwd ~/work/project
+```
 
 ---
 
@@ -190,9 +210,22 @@ Coffee CLI 同时消除两道门槛：**不需要终端经验，不需要懂英�
 
 ### 核心功能
 
-**多 Tab 会话** · **Gambit 快捷命令** · **Hook 自动化** · **会话历史** · **内置文件浏览器** · **任务板** · **Agent 安装器** · **远程终端**
+**多 Tab 会话** · **Gambit 快捷命令** · **Hook 自动化** · **会话历史** · **内置文件浏览器** · **任务板** · **Agent 安装器** · **远程终端** · **外部唤起**
 
 原生支持 11 种语言，开箱即用。
+
+### 外部唤起（命令行）
+
+`coffee-cli launch --tool <id> [--cwd <dir>]` 跳过启动台，直接新开一个指定 Agent、指定目录的标签页——适合启动器、资源管理器右键菜单、Raycast/Alfred、脚本别名。`--tool` 取注册表中的 id（`claude`、`codex`、`kimicode`、`hermes`……）；省略 `--cwd` 时沿用该工具上次使用的目录。应用已在运行时，请求会转发给运行中的实例新开标签页，不影响已有会话。
+
+```bash
+# macOS —— 建议直接调用二进制（应用已运行时，open -a 的 --args 会被系统丢弃）
+"/Applications/Coffee CLI.app/Contents/MacOS/coffee-cli" launch --tool kimicode --cwd /work/project
+# Windows —— 配合资源管理器右键菜单，用 %V 传入当前文件夹
+coffee-cli.exe launch --tool claude --cwd "C:\work\project"
+# Linux
+coffee-cli launch --tool codex --cwd ~/work/project
+```
 
 ### 安装
 

--- a/src-ui/src/components/center/CenterPanel.tsx
+++ b/src-ui/src/components/center/CenterPanel.tsx
@@ -867,6 +867,68 @@ export function CenterPanel() {
     });
   };
 
+  // External launch (`coffee-cli launch --tool <id> [--cwd <dir>]`) — reached
+  // from the cold-start drain (takePendingLaunch) and the warm-start
+  // single-instance forward ('launch-request' event). Reuses an idle
+  // launchpad tab when one exists so the agent never hijacks a tab that
+  // already runs a session; otherwise opens a fresh tab (same 5-tab cap as
+  // the + button).
+  const launchCtxRef = useRef({ terminals, activeTerminalId });
+  useEffect(() => { launchCtxRef.current = { terminals, activeTerminalId }; });
+  const applyLaunchRequest = (tool: ToolType, cwd?: string) => {
+    if (!BUILTIN_AI_CLI_FALLBACK.some(item => item.key === tool)) return;
+    const { terminals: terms, activeTerminalId: activeId } = launchCtxRef.current;
+    const current = terms.find(t => t.id === activeId);
+    let id: string;
+    if (current && current.tool === null) {
+      id = current.id;
+    } else {
+      const idle = terms.find(t => t.tool === null);
+      if (idle) {
+        id = idle.id;
+        dispatch({ type: 'SET_ACTIVE_TERMINAL', id });
+      } else {
+        if (terms.length >= 5) {
+          showToast(t('session.max'));
+          return;
+        }
+        id = crypto.randomUUID();
+        dispatch({ type: 'ADD_TERMINAL', session: { id, tool: null, folderPath: cwd ?? null } });
+      }
+    }
+    if (cwd) {
+      dispatch({ type: 'SET_FOLDER', path: cwd });
+      setLastCwdByTool(prev => {
+        const next = { ...prev, [tool as string]: cwd };
+        try { localStorage.setItem('coffee:last-cwd-by-tool', JSON.stringify(next)); } catch { /* storage full/blocked — non-fatal */ }
+        return next;
+      });
+      pushRecentFolder(cwd);
+    }
+    dispatch({ type: 'SET_TERMINAL_TOOL', id, tool });
+  };
+
+  // Drain the cold-start launch request once on mount, then keep listening
+  // for warm-start forwards emitted by the single-instance plugin (second
+  // process invoked as `launch …` — the running instance never restarts).
+  useEffect(() => {
+    if (!isTauri) return;
+    commands.takePendingLaunch()
+      .then(req => { if (req) applyLaunchRequest(req.tool as ToolType, req.cwd); })
+      .catch(() => {});
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        unlisten = await listen<{ tool: string; cwd?: string }>('launch-request', e => {
+          applyLaunchRequest(e.payload.tool as ToolType, e.payload.cwd);
+        });
+      } catch { /* event bridge unavailable (e.g. browser dev) — ignore */ }
+    })();
+    return () => { if (unlisten) unlisten(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleCloseTab = (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
     dispatch({ type: 'REMOVE_TERMINAL', id });

--- a/src-ui/src/styles/global.css
+++ b/src-ui/src/styles/global.css
@@ -957,9 +957,14 @@ html.is-macos #root {
     white-space: nowrap;
     flex-shrink: 0;
 }
-/* macOS: clear the native traffic lights (Overlay draws them top-left). */
+/* macOS: clear the native traffic lights (Overlay draws them top-left) with
+   a comfortable gap. The lights start at trafficLightPosition x:14
+   (tauri.macos.conf.json) and span ~54px → they end ≈68px; 76px left the
+   brand logo almost touching them (~8px), which read as cramped (issue
+   #102). 88px gives a ~20px breathing room between the green light and the
+   logo, matching the spacing Finder/ Safari keep around their own chrome. */
 html.is-macos .titlebar-left-slot .brand {
-    padding-left: 76px;
+    padding-left: 88px;
 }
 .titlebar-left-slot.is-collapsed {
     width: 0;

--- a/src-ui/src/tauri.ts
+++ b/src-ui/src/tauri.ts
@@ -172,6 +172,12 @@ export const commands = {
   checkToolsInstalled: () =>
     invoke<Record<string, boolean>>('check_tools_installed'),
 
+  // External launch request (`launch --tool <id> [--cwd <dir>]`) handed to
+  // the GUI at cold start. Drained exactly once by CenterPanel on mount —
+  // warm-start requests arrive as 'launch-request' events instead.
+  takePendingLaunch: () =>
+    invoke<{ tool: string; cwd?: string } | null>('take_pending_launch'),
+
   /** Probed availability of optional shells (pwsh / Git Bash / wsl on
    *  Windows; zsh/bash/fish/sh on Unix). Fed to the SettingsModal shell
    *  picker so it only shows shells the user actually has. Inbox shells

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,0 +1,150 @@
+//! External launch requests — `coffee-cli launch --tool <id> [--cwd <dir>]`.
+//!
+//! Lets launchers, context menus, and scripts open Coffee CLI directly
+//! into a fresh agent tab at a chosen folder, instead of landing on the
+//! launchpad and making the user pick the tool + folder by hand.
+//!
+//! Two delivery paths, one payload:
+//!
+//! - **Cold start** — `main.rs` parses argv and hands the request to
+//!   `server::start_ui`, which stores it in `AppState::pending_launch`.
+//!   The frontend drains it once via the `take_pending_launch` command
+//!   on mount.
+//! - **Warm start** — the app is already running; the second process's
+//!   argv is forwarded by the single-instance plugin, whose callback
+//!   re-parses it here and emits `launch-request` to the frontend (the
+//!   first process keeps running, so nothing is restarted).
+//!
+//! Examples:
+//!   macOS:   open -a "Coffee CLI" --args launch --tool kimicode --cwd /work/proj
+//!   Windows: coffee-cli.exe launch --tool claude --cwd "C:\work\proj"
+//!   Linux:   coffee-cli launch --tool codex --cwd ~/work/proj
+//!
+//! `--tool` must be a registered tool id (`claude`, `codex`, `kimicode`,
+//! `hermes`, …). Unknown tools and non-existent `--cwd` values are
+//! rejected here so a bad invocation degrades to the plain launchpad
+//! instead of erroring out in front of the user.
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchRequest {
+    pub tool: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+}
+
+/// Parse a `launch` subcommand from a raw argv (with or without argv[0]).
+/// Returns `None` when argv is not a launch request, the tool id is not
+/// registered, or `--cwd` points at a directory that doesn't exist.
+pub fn parse_launch_args(args: &[String]) -> Option<LaunchRequest> {
+    // `launch` must be the first real argument. argv[0] presence varies
+    // (bare exe name, full path, or single-instance forwarded argv), so
+    // accept it at index 0 or 1 instead of guessing argv[0]'s shape.
+    let start = match args.first().map(|s| s.as_str()) {
+        Some("launch") => 1,
+        _ if args.get(1).map(|s| s.as_str()) == Some("launch") => 2,
+        _ => return None,
+    };
+    let rest = &args[start..];
+
+    let mut tool: Option<String> = None;
+    let mut cwd: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        let arg = rest[i].as_str();
+        // Support both `--flag value` and `--flag=value`.
+        let (flag, inline_val) = match arg.split_once('=') {
+            Some((f, v)) if f.starts_with("--") => (f, Some(v.to_string())),
+            _ => (arg, None),
+        };
+        let next_val = |i: &mut usize| -> Option<String> {
+            if let Some(v) = inline_val.clone() {
+                return Some(v);
+            }
+            *i += 1;
+            rest.get(*i).cloned()
+        };
+        match flag {
+            "--tool" => tool = next_val(&mut i),
+            "--cwd" => cwd = next_val(&mut i),
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let tool = tool?;
+    // Unknown tool ids degrade to the plain launchpad.
+    crate::tools::find(&tool)?;
+
+    if let Some(dir) = &cwd {
+        if !std::path::Path::new(dir).is_dir() {
+            return None;
+        }
+    }
+    Some(LaunchRequest { tool, cwd })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn first_tool_id() -> &'static str {
+        crate::tools::TOOLS[0].id
+    }
+
+    #[test]
+    fn ignores_non_launch_argv() {
+        assert!(parse_launch_args(&argv(&["coffee-cli"])).is_none());
+        assert!(parse_launch_args(&argv(&["coffee-cli", "--help"])).is_none());
+        assert!(parse_launch_args(&argv(&["launch"])).is_none()); // missing --tool
+    }
+
+    #[test]
+    fn parses_tool_with_and_without_argv0() {
+        let id = first_tool_id();
+        let with0 = parse_launch_args(&argv(&["/usr/bin/coffee-cli", "launch", "--tool", id]));
+        let without0 = parse_launch_args(&argv(&["launch", "--tool", id]));
+        assert_eq!(with0.as_ref().map(|r| r.tool.as_str()), Some(id));
+        assert_eq!(without0.as_ref().map(|r| r.tool.as_str()), Some(id));
+        assert!(with0.unwrap().cwd.is_none());
+    }
+
+    #[test]
+    fn parses_equals_form_and_validates_cwd() {
+        let id = first_tool_id();
+        let ok = parse_launch_args(&argv(&[
+            "coffee-cli",
+            "launch",
+            &format!("--tool={}", id),
+            "--cwd=/tmp",
+        ]));
+        assert_eq!(ok.as_ref().and_then(|r| r.cwd.as_deref()), Some("/tmp"));
+
+        let bad = parse_launch_args(&argv(&[
+            "coffee-cli",
+            "launch",
+            "--tool",
+            id,
+            "--cwd",
+            "/definitely/not/a/real/dir-9f2b7",
+        ]));
+        assert!(bad.is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_tool() {
+        assert!(parse_launch_args(&argv(&[
+            "coffee-cli",
+            "launch",
+            "--tool",
+            "not-a-real-tool"
+        ]))
+        .is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod hook_forwarder;
 mod hook_installer;
 mod fonts;
 mod fs_watcher;
+mod launch;
 mod tool_config;
 mod tools;
 mod skills;
@@ -169,6 +170,10 @@ fn main() -> Result<()> {
     // with a known subcommand. This is opt-in; double-clicking the
     // executable still gets the GUI (no argv).
     let args: Vec<String> = std::env::args().collect();
+    // `launch --tool <id> [--cwd <dir>]` doesn't short-circuit: the GUI
+    // starts as usual, but the request rides along and the frontend drains
+    // it on mount (see launch.rs for the cold/warm delivery paths).
+    let pending_launch = launch::parse_launch_args(&args);
     if let Some(sub) = args.get(1) {
         match sub.as_str() {
             // Forward-compatible: unknown subcommands fall through
@@ -180,7 +185,7 @@ fn main() -> Result<()> {
 
     // Default: launch the GUI. Each tab picks its own CWD at
     // launch time — no initial directory needed.
-    server::start_ui()
+    server::start_ui(pending_launch)
 }
 
 /// Query the installed WebKit2GTK 4.1 minor version via dlopen +

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,6 +16,11 @@ pub struct AppState {
     /// workspace folder is open; None otherwise. Swapping this Mutex'd
     /// Option replaces the watcher atomically on folder switch.
     pub fs_watcher: Mutex<Option<crate::fs_watcher::FsWatcher>>,
+    /// External launch request passed via `launch --tool … [--cwd …]` argv.
+    /// Drained exactly once by the frontend (`take_pending_launch`) on mount;
+    /// warm-start requests skip this slot and arrive as `launch-request`
+    /// events from the single-instance callback instead (see launch.rs).
+    pub pending_launch: Mutex<Option<crate::launch::LaunchRequest>>,
 }
 
 
@@ -114,6 +119,15 @@ pub(crate) fn check_tool_unix(bin: &str) -> bool {
 #[tauri::command]
 fn install_hook_for_tool(tool: String) {
     crate::hook_installer::install_for_tool(&tool);
+}
+
+/// Drain the cold-start external launch request (`launch --tool … --cwd …`),
+/// if any. Exactly-once semantics — the first caller gets the request, every
+/// later caller gets `None`. Warm-start requests don't pass through here;
+/// they arrive as `launch-request` events from the single-instance callback.
+#[tauri::command]
+fn take_pending_launch(state: State<'_, AppState>) -> Option<crate::launch::LaunchRequest> {
+    state.pending_launch.lock().ok()?.take()
 }
 
 #[tauri::command]
@@ -3644,7 +3658,7 @@ pub fn set_tool_config(
     crate::tool_config::set(&tool, entry).map_err(|e| e.to_string())
 }
 
-pub fn start_ui() -> anyhow::Result<()> {
+pub fn start_ui(pending_launch: Option<crate::launch::LaunchRequest>) -> anyhow::Result<()> {
     // Create shared session BEFORE the builder so we can clone it for the exit handler
     let terminal_session = terminal::SharedSession::default();
 
@@ -3664,12 +3678,20 @@ pub fn start_ui() -> anyhow::Result<()> {
     // share the bundle identifier, and the lock would silently redirect the
     // dev launch to the production process and exit.
     #[cfg(not(debug_assertions))]
-    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
         use tauri::Manager;
         if let Some(w) = app.get_webview_window("main") {
             let _ = w.unminimize();
             let _ = w.show();
             let _ = w.set_focus();
+        }
+        // A second instance invoked as `launch --tool … --cwd …` forwards
+        // its argv here — re-parse and hand the request to the frontend of
+        // the ALREADY-RUNNING instance, so the launcher works without
+        // restarting the app or touching existing tabs (see launch.rs).
+        if let Some(req) = crate::launch::parse_launch_args(&args) {
+            use tauri::Emitter;
+            let _ = app.emit("launch-request", req);
         }
     }));
 
@@ -3681,6 +3703,7 @@ pub fn start_ui() -> anyhow::Result<()> {
             terminal_session,
             hook_port: std::sync::atomic::AtomicU16::new(0),
             fs_watcher: Mutex::new(None),
+            pending_launch: Mutex::new(pending_launch),
         })
         .invoke_handler(tauri::generate_handler![
             crate::fonts::list_system_fonts,
@@ -3707,6 +3730,7 @@ pub fn start_ui() -> anyhow::Result<()> {
             detect_shells,
             crate::tools::list_tools,
             install_hook_for_tool,
+            take_pending_launch,
             start_fs_watcher,
             stop_fs_watcher,
             save_clipboard_image,

--- a/tauri.macos.conf.json
+++ b/tauri.macos.conf.json
@@ -19,7 +19,7 @@
         "hiddenTitle": true,
         "trafficLightPosition": {
           "x": 14,
-          "y": 14
+          "y": 22
         }
       }
     ]


### PR DESCRIPTION
## 这个 PR 包含两个改动

### 1. feat: 外部唤起子命令 `coffee-cli launch --tool <id> [--cwd <dir>]`

**动机**：目前没有任何外部入口可以让 Coffee CLI 启动（或激活）后直接进入"某个 Agent + 指定工作目录"的标签页。启动器类应用（Finder 工具栏按钮、Windows 资源管理器右键菜单、Raycast/Alfred 等）只能 `open` 应用停在启动台，用户还得手动点卡片、选文件夹。

**用法**：

```bash
# macOS（推荐直接调二进制；open -a 在应用已运行时会被系统吞掉 --args）
"/Applications/Coffee CLI.app/Contents/MacOS/coffee-cli" launch --tool kimicode --cwd /work/proj
# Windows（配合资源管理器右键菜单，%V 传入当前文件夹，示例 .reg 见文末附录）
coffee-cli.exe launch --tool claude --cwd "C:\work\proj"
# Linux
coffee-cli launch --tool codex --cwd ~/work/proj
```

**行为**：

- 冷启动：应用启动后直接处于该 Agent 的新标签页，cwd 为指定目录。
- 热启动（已在运行）：通过 single-instance 插件把请求转发给已运行实例，新开标签页，已有会话不受影响（不重启、不占已有标签；macOS 上需直接调二进制，`open -a` 的 `--args` 会被 LaunchServices 丢弃）。
- 复用空闲的启动台标签；没有空闲时新开（沿用 + 按钮的 5 标签上限）。
- `--tool` 必须是注册表里的 id（`claude` / `codex` / `kimicode` / `hermes` / `opencode` …）；未知 id、不存在的 `--cwd` 都会静默回退到普通启动台，不打扰用户。
- `--cwd` 省略时沿用卡片同款 `last-cwd-by-tool` 记忆。

**实现**（改动很小，全部复用现有积木）：

- 新增 `src/launch.rs`：argv 解析与校验（支持 `--flag value` / `--flag=value`），含 4 个单元测试。
- `src/main.rs`：解析到的请求随 `start_ui(pending)` 存入 `AppState::pending_launch`。
- `src/server.rs`：新增 `take_pending_launch` 命令（exactly-once）；single-instance 回调从忽略 `_args` 改为解析并 `emit("launch-request", req)`。
- 前端 `CenterPanel.tsx`：挂载时 drain 冷启动请求 + 监听 `launch-request` 事件，`applyLaunchRequest` 复用卡片点击相同的 `SET_FOLDER` + `SET_TERMINAL_TOOL` 路径。
- README 新增 "External Launch" 章节（英文 + 简体中文）：三平台用法与行为说明。

**测试**：

- `cargo test launch::` — 4 个用例全过（无 argv0 / 有 argv0 / `--flag=value` / 无效 cwd / 未知 tool 回退）。
- macOS arm64 实测（tauri build 的 .app）：冷启动直达 kimi 标签且 cwd 正确；热启动转发后新开 claude 标签、原 kimi 会话不受影响；无效参数落到启动台。
- Windows 未实测（开发机没有 Windows），但代码路径与 macOS/Linux 完全一致（arg 解析、single-instance、前端均为跨平台），Windows 右键菜单的 `.reg` 示例已附在文末，欢迎验证。

### 2. fix: macOS 标题栏红绿灯与 logo 布局（closes #102）

40px 自定义标题栏里有两处拥挤/错位：

- **红绿灯偏高**：`trafficLightPosition y:14` 使红绿灯中心在 +12px，比垂直居中的 logo（+20px）高出 8px，肉眼明显悬浮。改为 `y:22`，红绿灯中心落到 +20px，与 logo 同线（已按渲染帧实测验证）。
- **logo 间距不足**：`html.is-macos .titlebar-left-slot .brand` 的 `padding-left: 76px` 只比红绿灯右缘（≈68px）多约 8px，logo 几乎贴着绿灯。调整为 `88px`（约 20px 间距），并补充注释说明尺寸依据。

Windows/Linux 不受影响。

---

Test plan:
- `cargo test launch::` ✅
- `cd src-ui && npm run build`（tsc + vite）✅
- `npx eslint CenterPanel.tsx tauri.ts` 与 main 分支基线一致（37 条历史遗留，不新增）✅
- macOS arm64 真机：launch 冷启动 / 热启动 / 无效参数回退 ✅
- macOS arm64 真机：标题栏红绿灯与 logo 垂直居中（渲染帧实测）✅

---

## 附：Windows 右键菜单示例（.reg）

导入后，文件夹上右键出现 "Open Kimi Code here"（按需复制一份改成 `--tool claude`）：

```reg
Windows Registry Editor Version 5.00

[HKEY_CLASSES_ROOT\Directory\shell\CoffeeCliKimi]
@="Open Kimi Code here"
"Icon"="\"C:\\Program Files\\Coffee CLI\\coffee-cli.exe\""

[HKEY_CLASSES_ROOT\Directory\shell\CoffeeCliKimi\command]
@="\"C:\\Program Files\\Coffee CLI\\coffee-cli.exe\" launch --tool kimicode --cwd \"%V\""

[HKEY_CLASSES_ROOT\Directory\Background\shell\CoffeeCliKimi]
@="Open Kimi Code here"
"Icon"="\"C:\\Program Files\\Coffee CLI\\coffee-cli.exe\""

[HKEY_CLASSES_ROOT\Directory\Background\shell\CoffeeCliKimi\command]
@="\"C:\\Program Files\\Coffee CLI\\coffee-cli.exe\" launch --tool kimicode --cwd \"%V\""
```

（exe 路径按实际安装位置调整，例如 per-user 安装在 `%LOCALAPPDATA%\Coffee CLI\`。）
