### PR TITLE
fix(launchpad): remove pin cap and restore long-grid scrolling

### DIFF
--- a/src-ui/src/components/center/CenterPanel.css
+++ b/src-ui/src/components/center/CenterPanel.css
@@ -301,7 +301,13 @@
   height: 100%;
   flex-shrink: 0;
   display: flex;
-  align-items: center;
+  /* Keep the page's scroll origin at its actual top. Centering a tall
+     flex item here gives it a negative cross-axis offset, so its first
+     rows sit above scrollTop: 0 and cannot be reached after pinning many
+     tools. Desktop content centers itself with auto margins below instead:
+     those margins absorb spare space when it fits, but resolve to zero
+     when it overflows. */
+  align-items: flex-start;
   justify-content: center;
   overflow-y: auto;
 }
@@ -350,6 +356,13 @@
   max-width: 628px;
   width: 100%;
   padding: 32px;
+}
+
+/* Preserve the sparse-desktop composition without sacrificing a reachable
+   scroll origin for a long pinned grid. Library pages manage their own top
+   alignment and header clearance, so this is deliberately desktop-only. */
+.launchpad-page:not(.library-page) .launchpad-inner {
+  margin-block: auto;
 }
 
 .launchpad-grid {

--- a/src-ui/src/components/center/CenterPanel.tsx
+++ b/src-ui/src/components/center/CenterPanel.tsx
@@ -412,7 +412,7 @@ const SvgPlus = ({ active }: { active: boolean }) => (
 // drop obsolete IDs from `coffee_pinned_items` (e.g. `agent:vibeid`
 // from back when /vibeid was a launcher tool, before it became a
 // regular skill). Without this, retired pins inflate the
-// "Agents N/MAX_PINS" counter on the library tab — the stale cards
+// "Agents N" counter on the library tab — the stale cards
 // render nothing because no AGENT_CATALOG entry matches, but they
 // still count. Update this set when adding or removing AGENT_CATALOG
 // entries below.
@@ -466,9 +466,6 @@ export function CenterPanel() {
   const [showLibrary, setShowLibrary] = useState(false);
   const [libraryTab, setLibraryTab] = useState<'agents' | 'skills'>('agents');
   const [pinnedItems, setPinnedItems] = useState<string[]>(() => {
-    // Hard cap must match MAX_PINS constant below. Inlined as a literal
-    // because MAX_PINS is declared after this initializer runs.
-    const CAP = 6;
     try {
       const stored = localStorage.getItem('coffee_pinned_items');
       if (stored !== null) {
@@ -485,20 +482,17 @@ export function CenterPanel() {
         // `agent:vibeid` after /vibeid became a skill, or the other retired
         // coordinated tools `agent:two-agent` / `agent:three-agent` /
         // `agent:hyper-agent`). These ghosts render nothing but inflate the
-        // "Agents N/6" counter.
+        // "Agents N" counter.
         arr = arr.filter((id: unknown) =>
           typeof id === 'string' && id.startsWith('agent:') && VALID_PIN_KEYS.has(id.slice('agent:'.length))
         );
-        // Defensive cap: historical bugs (e.g. earlier migrations that
-        // pushed past the limit) may have left > CAP items in storage.
-        // Trim and persist back so the state stays consistent.
-        if (arr.length > CAP) arr = arr.slice(0, CAP);
         try { localStorage.setItem('coffee_pinned_items', JSON.stringify(arr)); } catch {}
         return arr;
       }
-      // First launch: pre-pin 6 useful defaults so desktop shows a full MAX_PINS
-      // grid out of the box (4 AI CLIs covering major providers + 2 utilities).
-      // Returning users' pin choices are respected (stored !== null path above).
+      // First launch: pre-pin a useful default set so the desktop isn't
+      // empty out of the box (4 AI CLIs covering major providers + 2
+      // utilities). Returning users' pin choices are respected (stored !==
+      // null path above).
       const defaults = [
         'agent:claude',
         'agent:codex',
@@ -511,8 +505,6 @@ export function CenterPanel() {
       return defaults;
     } catch { return []; }
   });
-
-  const MAX_PINS = 6;
 
   // Agent list is fully local (baked into BUILTIN_AI_CLI_FALLBACK below) — no
   // loading / cache state here. The remote catalog fetch at
@@ -611,7 +603,6 @@ export function CenterPanel() {
       if (isPinned) {
         next = prev.filter(x => x !== id);
       } else {
-        if (prev.length >= MAX_PINS) return prev;
         next = [...prev, id];
       }
       try { localStorage.setItem('coffee_pinned_items', JSON.stringify(next)); } catch {}
@@ -1969,7 +1960,7 @@ export function CenterPanel() {
                 className={`library-tab ${libraryTab === 'agents' ? 'active' : ''}`}
                 onClick={() => setLibraryTab('agents')}
               >
-                Agents {pinnedItems.length}/{MAX_PINS}
+                Agents {pinnedItems.length}
               </button>
               <button
                 className={`library-tab ${libraryTab === 'skills' ? 'active' : ''}`}
@@ -2008,4 +1999,3 @@ export function CenterPanel() {
     </>
   );
 }
-


### PR DESCRIPTION
## 为什么

启动台桌面的 pin 上限写死为 6；在已有 15+ 个 CLI 的注册表中，用户想固定第 7 个工具时必须先取消一个，尽管网格本来就会自动换行。

移除上限后还暴露了一个布局问题：当 pin 很多时，启动页把过高的内容在滚动容器内垂直居中，首行会落到 `scrollTop: 0` 之上，因而无法滚回最顶部。

## 改动内容

- 移除 `MAX_PINS = 6`、第 7 个 pin 的拦截以及初始化时的 6 项裁剪；
- Library 计数从 `Agents N/6` 改为 `Agents N`；
- 保留首次启动默认固定的 6 个常用项、去重和有效 ID 校验；
- 长网格以真正的顶部作为滚动原点；仅在内容未溢出时用自动边距保持原来的桌面垂直居中，因此首行始终可滚回。

已有存储中的有效 pin 今后不会再被裁剪；旧版本已经删除掉的条目无法凭空恢复。

## 验证

- `cargo check` ✅
- `cd src-ui && npm run build` ✅
- macOS arm64：连续固定 17 个工具，网格可从底部滚回首行；重启应用后 17 项选择完整保留，Library 计数正常。