### PR TITLE
fix(layout): adapt launchpad cards and side rails to narrow windows

### DIFF
--- a/src-ui/src/components/center/CenterPanel.css
+++ b/src-ui/src/components/center/CenterPanel.css
@@ -503,12 +503,15 @@
   border: none;
   border-radius: 0;
   box-shadow: none;
-  padding: 16px 16px 16px 24px;
+  /* Fluid horizontal costs: on narrow windows the padding/gap shrink
+     before the name has to ellipsize (issue: agent name overlapped the
+     folder icon when the window was compressed horizontally). */
+  padding: 16px clamp(8px, 1.2vw, 16px) 16px clamp(14px, 1.8vw, 24px);
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
-  gap: 12px;
+  gap: clamp(6px, 0.9vw, 12px);
   height: 80px;
   cursor: pointer;
   position: relative;
@@ -609,8 +612,11 @@
 .folder-menu-item .folder-menu-del svg { opacity: 1; color: inherit; }
 
 .launchpad-folder-btn svg {
-  width: 28px;
-  height: 28px;
+  /* Fluid with the card: full 28px at normal widths, down to 22px on
+     narrow windows so the button stays affordable (name ellipsizes first,
+     the folder affordance never gets overlapped). */
+  width: clamp(22px, 2vw, 28px);
+  height: clamp(22px, 2vw, 28px);
   flex-shrink: 0;
 }
 
@@ -637,12 +643,13 @@
 
 
 .launchpad-icon {
-  /* Fixed pixel box. Every icon inside is forced to fill this box so
-     visual sizes stay uniform regardless of the source asset's internal
+  /* Fluid pixel box (44px at normal widths, down to 32px on narrow
+     windows). Every icon inside is forced to fill this box so visual
+     sizes stay uniform regardless of the source asset's internal
      viewBox utilization (brand SVGs had wildly different content-to-
      viewBox ratios before). Tune here if the grid density changes. */
-  width: 44px;
-  height: 44px;
+  width: clamp(32px, 3.2vw, 44px);
+  height: clamp(32px, 3.2vw, 44px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -666,13 +673,26 @@
   flex-direction: column;
   gap: 3px;
   min-width: 0;
+  /* Clip the name when the card gets too narrow — the span below
+     ellipsizes instead of painting over the folder button (narrow-window
+     overlap fix). */
+  overflow: hidden;
 }
 
 .launchpad-card span {
-  font-size: 18px; /* Increased text size */
+  font-size: clamp(15px, 1.35vw, 18px);
   font-weight: 500;
   color: var(--text-1);
   white-space: nowrap;
+}
+
+/* Agent name: ellipsize when the card is squeezed instead of overflowing
+   onto the folder button. The terminal card's inline-flex name (with the
+   remote-link icon) only clips — flex items can't ellipsize — which is
+   fine for its short CJK label. */
+.launchpad-card-info > span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .launchpad-card-cwd {
@@ -683,7 +703,9 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 160px;
+  /* Shrink with the card (was a fixed 160px that could out-wide a narrow
+     card and overflow). */
+  max-width: 100%;
   letter-spacing: 0.3px;
 }
 

--- a/src-ui/src/styles/global.css
+++ b/src-ui/src/styles/global.css
@@ -138,8 +138,20 @@ textarea,
     --transition: 0.2s ease;
 
     /* Panel Config */
-    --w-left: 320px;
-    --w-right: 320px;
+    /* Both rails fluid: full 320px on wide windows, shrinking toward 240px
+       as the window narrows — at the app's own 900px minimum width the two
+       rails + the center's 400px minimum used to total 1040px, pushing the
+       right rail (task list / note cards) off the window's right edge and
+       clipping card text. The left rail's titlebar slot references the same
+       var, so the tab strip stays aligned with the center column at any
+       width; its traffic-light clearance comes from the brand's own 88px
+       padding, not from the rail width. */
+    --w-left: clamp(240px, 28vw, 320px);
+    /* The right rail additionally YIELDS below this value (flex-shrink,
+       min-width 200px on .panel-right) when space runs out — it is the
+       last flex item and clips first. Everything positioning against it
+       (Gambit's right offset) references this var and stays in sync. */
+    --w-right: clamp(240px, 28vw, 320px);
     --gap: 16px;
 
     /* ─── Shape form defaults (overridden by [data-shape]) ──────── */
@@ -1327,8 +1339,13 @@ body.gambit-docked .multi-agent-grid-standalone {
 /* ─── Right Panel (Compiler) ─────────────────────────── */
 .panel-right {
     width: var(--w-right);
-    min-width: var(--w-right);
-    flex-shrink: 0;
+    /* Floor for the rail when horizontal space runs short: --w-right is the
+       PREFERRED width (fluid clamp, see :root); with the default flex-shrink:1
+       the rail yields below it — down to this floor — instead of being pushed
+       off the window's right edge and clipping the task list / note cards
+       (narrow-window adaptation). .is-collapsed still overrides to 0 for the
+       slide-shut animation. */
+    min-width: 200px;
     display: flex;
     flex-direction: column;
     /* Slide-animation match for .panel-left — see comment there. */


### PR DESCRIPTION
## Why

Compressing the window horizontally broke two surfaces:

1. **Launchpad agent cards** — the 18px agent name (`white-space: nowrap`, unclipped) outgrew its squeezed info column and painted over the card's folder button.
2. **Right rail (task list / note cards)** — at the app's own 900px minimum width, the fixed 320px left rail + 400px center minimum + 320px right rail totalled **1040px**, so the right rail was pushed past the window's right edge and card text was clipped mid-glyph.

## What

**`CenterPanel.css` (launchpad cards)**

- The info column clips and the agent name ellipsizes instead of overflowing.
- Fixed horizontal costs turn fluid via `clamp()`: icon 44→32px, name 18→15px, card padding/gap, folder glyph 28→22px — smooth degradation on narrow windows, pixel-identical on wide ones.
- The cwd label's fixed `max-width: 160px` becomes `100%` so it shrinks with the card.

**`global.css` (side rails)**

- `--w-left` / `--w-right` are now `clamp(240px, 28vw, 320px)`; the right rail additionally yields below that (`flex-shrink`, 200px floor) as the last flex item. At 900px the layout totals exactly 900 with both rails fully visible; at 1200px+ nothing changes.
- The titlebar's left slot uses the same `--w-left` var, so the tab strip stays aligned with the center column; traffic-light clearance comes from the brand's own 88px padding, not the rail width. Gambit's right offset references `--w-right` and stays in sync.

## Verification

- Playwright layout probes at 560 / 800 / 900 / 1200 / 1600px: no name/folder overlap at any width; both rails fully on-screen from the 900px minimum width up (below that the right rail degrades to its 200px floor instead of disappearing off-window).
- `cargo check` and `cd src-ui && npm run build` both green.