### PR TITLE
fix(terminal): force full repaint after alt-screen TUI scroll to clear WebGL smear

### DIFF
--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -932,6 +932,33 @@ function TierTerminalImpl({
       return true; // Let xterm handle all other keys natively
     });
 
+    // ── Post-scroll full repaint (WebGL smear mitigation) ─────────────────
+    // In alt-screen TUIs that capture the mouse (Claude Code fullscreen), every
+    // wheel notch is forwarded as mouse escape sequences and the TUI answers
+    // with a complete full-screen ANSI redraw. Under WebView2's ANGLE/D3D
+    // compositor, bursts of back-to-back full-frame redraws can leave the GL
+    // canvas holding stale row textures — visible AFTER the scroll stops as a
+    // vertical band of ghost text along the edge and cell-level misalignment
+    // ("滑动之后页面文字错位"). Same WebGL framebuffer-staleness family as
+    // issues #47 / #74, but those masks only cover tab-switch / window-focus,
+    // not the scroll path. Fix: shortly after the LAST wheel event of a
+    // gesture, re-mark every row dirty so the renderer re-uploads all row
+    // textures once the redraw storm settles. Cost is one extra viewport
+    // repaint per scroll gesture (debounced); harmless on the DOM renderer.
+    let scrollRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+    const schedulePostScrollRefresh = () => {
+      if (scrollRefreshTimer !== null) clearTimeout(scrollRefreshTimer);
+      scrollRefreshTimer = setTimeout(() => {
+        scrollRefreshTimer = null;
+        try {
+          if (term.rows > 0) term.refresh(0, term.rows - 1);
+        } catch { /* term disposed */ }
+      }, 150);
+    };
+    unlisteners.push(() => {
+      if (scrollRefreshTimer !== null) clearTimeout(scrollRefreshTimer);
+    });
+
     // ── Alternate-scroll mode (mouse wheel in full-screen TUIs) ───────────
     // Real terminals (Windows Terminal, iTerm2, xterm) translate the mouse
     // wheel into arrow-key presses when an app is in the ALTERNATE screen
@@ -952,8 +979,10 @@ function TierTerminalImpl({
     term.attachCustomWheelEventHandler((e) => {
       try {
         const inAltScreen = term.buffer.active.type === 'alternate';
+        if (!inAltScreen) return true; // normal buffer → xterm scrolls scrollback
+        if (e.deltaY !== 0) schedulePostScrollRefresh();
         const mouseOff = term.modes.mouseTrackingMode === 'none';
-        if (!inAltScreen || !mouseOff || e.deltaY === 0) return true;
+        if (!mouseOff || e.deltaY === 0) return true;
 
         // Normalize the platform's wheel delta into a line count. WebView2 on
         // Windows reports pixel deltas (deltaMode 0, ~100px/notch); some mice


### PR DESCRIPTION
## Symptom

When scrolling inside a full-screen TUI that captures the mouse (e.g. Claude Code fullscreen mode), the terminal shows **misaligned text and a vertical band of ghost characters** along the edge after the scroll stops. The ghost band contains fragments of previously rendered frames.

## Root cause

In alt-screen + mouse-capture mode, every wheel notch is forwarded to the TUI as mouse escape sequences, and the TUI answers with a complete full-screen ANSI redraw. Under WebView2's ANGLE/D3D compositor, bursts of back-to-back full-frame redraws can leave the WebGL canvas holding stale row textures once the redraw storm settles.

This is the same framebuffer-staleness family already handled for tab-switch (#47) and window-focus (#74) — but those masks don't cover the scroll path, which had no protection.

## Fix

In `TierTerminal.tsx`'s custom wheel handler: when a wheel event lands in alt-screen, arm a 150ms debounced timer. After the **last** wheel event of a scroll gesture, `term.refresh(0, rows - 1)` re-marks every row dirty, forcing the renderer to re-upload all row textures and clearing any torn frame.

- Cost: one extra viewport repaint per scroll gesture (debounced)
- Harmless on the DOM renderer fallback
- Timer cleaned up on unmount; normal-buffer scrollback scrolling is unaffected

## Testing

- `npm run build` (tsc + vite) green
- Rendering artifact is GPU-compositor dependent, so I could not force a reproduction on demand; the fix follows the same pattern as the existing #47/#74 mitigations, targeted at the scroll trigger