### PR TITLE
fix(terminal): handle OSC 52 so TUI-driven copy reaches the OS clipboard

### DIFF
--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -981,6 +981,36 @@ function TierTerminalImpl({
       }
     });
 
+    // ── OSC 52 clipboard write (TUI-driven copy) ─────────────────────────
+    // Full-screen TUIs that capture the mouse (Claude Code fullscreen) draw
+    // their OWN selection highlight and copy by emitting OSC 52 — xterm's
+    // buffer never holds a selection, so hasSelection() stays false and every
+    // app-level copy path (Ctrl+C, right-click ▸ Copy) is disabled while the
+    // TUI toasts "copied". The OS clipboard is never updated, so the text
+    // pastes nowhere outside (and the TUI's toast is lying). xterm.js core
+    // deliberately does NOT implement OSC 52 (InputHandler.ts lists
+    // "52 - Manipulate Selection Data" as a comment only) — the embedder must
+    // wire it. Decode the base64 payload (UTF-8 safe — raw atob would mangle
+    // CJK) and write via the Tauri clipboard plugin; navigator.clipboard
+    // would pop the WebView2 permission prompt (project clipboard rule,
+    // issue #96). Read queries (Pd = '?') are refused — returning false lets
+    // xterm swallow the sequence unanswered.
+    const osc52 = term.parser.registerOscHandler(52, (data: string) => {
+      try {
+        const sep = data.indexOf(';');
+        if (sep === -1) return false;
+        const payload = data.slice(sep + 1);
+        if (payload === '?' || payload === '') return false;
+        const bytes = Uint8Array.from(atob(payload), (ch) => ch.charCodeAt(0));
+        const text = new TextDecoder().decode(bytes);
+        if (text) clipboardWrite(text);
+        return true;
+      } catch {
+        return false; // malformed base64 — not ours to handle
+      }
+    });
+    unlisteners.push(() => osc52.dispose());
+
     // Clickable links: URLs only (http/https/file). Bare file/dir paths are
     // intentionally NOT matched — unquoted paths with spaces (e.g. Windows
     // "Coffee CLI_3.0.3...exe") can't be reliably bounded by a regex (would


### PR DESCRIPTION
## Symptom

In Claude Code fullscreen (mouse-captured), drag-selecting text shows the TUI's own highlight and a "copied" toast — but the text **pastes nowhere outside the terminal**. Meanwhile right-click ▸ Copy in the terminal is grayed out and Ctrl+C does nothing.

## Root cause

Claude Code draws its **own** selection and copies by emitting **OSC 52** (`ESC ] 52 ; c ; <base64> BEL`). xterm's buffer never holds a selection, so `hasSelection()` stays false — every app-level copy path (Ctrl+C, right-click ▸ Copy) is disabled, and the toast is lying: the OS clipboard is never updated.

xterm.js core deliberately does **not** implement OSC 52 (`InputHandler.ts` lists `52 - Manipulate Selection Data` as a comment only) — the embedder must wire it, and Coffee CLI had no handler.

## Fix

Register `term.parser.registerOscHandler(52, ...)` in `TierTerminal.tsx`'s init effect:

- Splits `Pc ; Pd`, decodes the base64 payload **UTF-8 safe** (`atob` → `Uint8Array` → `TextDecoder`, so CJK text survives)
- Writes via the Tauri clipboard plugin (`@/lib/clipboard`) — never `navigator.clipboard`, which pops the WebView2 permission prompt (project clipboard rule, #96)
- Read queries (`Pd = '?'`) and empty/malformed payloads are refused (return `false`)
- Handler disposed on unmount

Note: right-click ▸ Copy staying gray in mouse-captured TUIs is expected — xterm never owns that selection. After this fix, the TUI's own select-to-copy actually lands on the OS clipboard and pastes everywhere.

## Testing

- `npm run build` (tsc + vite) green
- Not yet verified in a live Claude Code session — worth a quick manual check: select text in fullscreen → toast appears → paste in another app