### PR TITLE
fix(terminal): use Unicode 11 width tables so emoji-bearing table rows stop misaligning

### DIFF
--- a/src-ui/package-lock.json
+++ b/src-ui/package-lock.json
@@ -13,6 +13,7 @@
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-global-shortcut": "^2.3.1",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
@@ -1913,6 +1914,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmmirror.com/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {

--- a/src-ui/package.json
+++ b/src-ui/package.json
@@ -15,6 +15,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",

--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -12,6 +12,7 @@ import { memo, useEffect, useLayoutEffect, useRef, useState, useCallback } from 
 import { createPortal } from 'react-dom';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { clipboardRead, clipboardWrite, clipboardReadImage } from '../../lib/clipboard';
 import { subscribeTerminalEvents } from '../../lib/pty-event-bus';
@@ -553,11 +554,27 @@ function TierTerminalImpl({
       // shells the caret simply hides while the terminal is unfocused.
       cursorInactiveStyle: 'none',
       scrollback: 5000,
+      // Required to load Unicode11Addon below (xterm 6 gates the unicode
+      // provider API as proposed). No other proposed API is used.
+      allowProposedApi: true,
       theme: buildXtermTheme(theme, hasBg, termColorScheme, isRawShell),
     });
 
     const fit = new FitAddon();
     term.loadAddon(fit);
+
+    // Unicode 11 width tables. xterm's default V6 wcwidth scores common
+    // emoji as NARROW (✅ ❌ ⭐ 🚀 = 1 cell) while modern CLI frameworks
+    // (Claude Code's Ink, etc.) measure them as 2. Every table row
+    // containing one of these is then laid out 1 cell short per emoji: the
+    // fresh right border lands early and the PREVIOUS frame's border in
+    // that column is never overwritten — a stale border column that no
+    // repaint can fix (it's buffer layout, not rendering). That was the
+    // "涉及表格就错位 / 错位后不自愈" bug chased blindly in #110/#112.
+    // Registering the V11 provider aligns our cell accounting with the
+    // apps'. Same reason VS Code loads this addon in its terminal.
+    term.loadAddon(new Unicode11Addon());
+    term.unicode.activeVersion = '11';
 
     // Register focus function in the singleton focus registry.
     // CenterPanel handles the global focusin/mouseup listener and routes


### PR DESCRIPTION
## Root cause found — with a reliable repro

The user report that closed #112 ("tables misalign, scrolling makes it worse, never self-heals") turned out to be **buffer layout, not WebGL** — which is why neither #110 nor #112 could fix it, and why the smear-chasing approach was doomed. The repro trigger: **any table row containing ✅ ❌ ⭐ 🚀 style emoji** (Claude Code renders these constantly in its summary tables).

xterm's default **V6** wcwidth scores these emoji as **narrow (1 cell)**; modern CLI frameworks (Claude Code's Ink, etc.) measure them as **2** per Unicode 11+. Consequences per affected row:

1. The row is laid out 1 cell short per emoji — the fresh right border lands early (ragged tables).
2. The previous frame's border glyph in that column is **never overwritten**, because every redraw also stops short — a persistent stale border column (the "extra column of fragments" in the user's screenshot).
3. Cursor-relative redraws (Ink's "move up N lines, overwrite") drift further with every affected row, so scrolling redrawing the table compounds the damage. It never self-heals because no repaint can change where the buffer placed the cells.

## Verification (headless, @xterm/headless 6.0.0)

| codepoint | V6 (current) | V11 (this PR) |
|---|---|---|
| U+2705 ✅ | 1 | 2 |
| U+274C ❌ | 1 | 2 |
| U+2B50 ⭐ | 1 | 2 |
| U+1F680 🚀 | 1 | 2 |

An 80-column modern-width table row (`│✅` + padding + `│`) lands the right border at column 79 under V6 and exactly at 80 under V11. CJK, box-drawing, quotes, dashes are identical under both providers (probed U+4E2D, U+300C/D, U+2014, U+2026, U+2500/2502 …), so this changes nothing for plain-CJK layouts.

## Fix

Register `@xterm/addon-unicode11` and set `unicode.activeVersion = '11'` at terminal init — the same provider VS Code loads in its integrated terminal. `allowProposedApi: true` is required (xterm 6 gates the unicode provider API; verified the addon throws without it); no other proposed API is used.

`npm run build` green; eslint on the touched file unchanged vs main. Given the history here, a real-machine check with a Claude Code table full of ✅/❌ is still worth doing, but for the first time the mechanism is proven rather than guessed.