### PR TITLE
fix(ui): give the active chrome tab a visible accent bar and a min-width

### DIFF
--- a/src-ui/src/components/center/CenterPanel.css
+++ b/src-ui/src/components/center/CenterPanel.css
@@ -46,7 +46,10 @@
   user-select: none;
   flex: 0 1 auto;
   max-width: 200px;
-  min-width: 0;
+  /* Content-sized width, but never narrower than this — short titles
+     (e.g. a codex tab titled "usage") otherwise shrink to a sliver that
+     reads as a different kind of control next to wider tabs. */
+  min-width: 120px;
   /* `transform` is part of the transition so siblings ease into their
    * shifted positions when another tab is being dragged past them
    * (browser-style slide-aside). The dragged tab itself overrides
@@ -63,6 +66,12 @@
 .chrome-tab.active {
   color: var(--text-1);
   background: var(--bg-terminal);
+  /* 2px accent bar across the top edge — the one active cue that survives
+     every shape. --bg-terminal ≈ --bg-app in all themes, and glass/carbon
+     strip the fill entirely (global.css), so fill+text alone left the
+     active tab nearly indistinguishable. sharp/panel keep their own 1px
+     variant via higher-specificity rules in global.css. */
+  box-shadow: inset 0 2px 0 0 var(--accent);
   z-index: 2;
   /* Prevent active tab from lagging behind during theme changes (flash bug) */
   transition: color 0.15s;
@@ -90,7 +99,9 @@
 /* The Chrome "flare" pseudo-elements that seamed the active tab into the
    terminal directly below it were removed when the strip moved up into the
    titlebar — there's no adjacent terminal to bridge into up here. The active
-   tab now reads via its --bg-terminal fill alone (WT-style flat tab). */
+   tab reads via its --bg-terminal fill plus a 2px top accent bar (see
+   .chrome-tab.active) — the bar is what carries the active state in the
+   transparent shapes (glass/carbon) where the fill is stripped. */
 
 .chrome-tab-new {
   width: 28px;

--- a/src-ui/src/styles/global.css
+++ b/src-ui/src/styles/global.css
@@ -1633,8 +1633,9 @@ body.gambit-docked .multi-agent-grid-standalone {
 }
 
 /* Tab family — chrome / Explorer / TaskBoard tab strips go fully
-   transparent in glass. Active state indicated by text-1 color
-   contrast alone (source default). No container pill, no active
+   transparent in glass. Active state is indicated by brighter text-1
+   color plus the 2px top accent bar on .chrome-tab.active (box-shadow
+   survives the background strip below). No container pill, no active
    fill, no outline. Matches the "全部透明,只靠主背景半透层"
    architecture: every tab IS the body's --glass-tint — adding any
    local bg would stack a second visible layer.
@@ -1652,7 +1653,8 @@ body.gambit-docked .multi-agent-grid-standalone {
    re-strip here: every tab (active + hover included) stays fully transparent
    and shows the body's single --glass-tint / carbon mesh, instead of stacking
    an opaque --bg-terminal fill. The active tab is distinguished by brighter
-   text (rule above / --text-1), not a fill — the glass "no local layer" rule. */
+   text (rule above / --text-1) plus the 2px top accent bar — a box-shadow,
+   which this background strip doesn't remove. */
 :is([data-shape="glass"], [data-shape="carbon"]) .chrome-tab {
     background: transparent !important;
 }


### PR DESCRIPTION
## Problem

Two tab-bar readability issues:

1. **Active tab is nearly indistinguishable.** Its only cue is the `--bg-terminal` fill, which matches the app background in every theme — and in the glass/carbon shapes the fill is stripped entirely (`background: transparent !important`), leaving only a subtle text brightness difference (`--text-2` → `--text-1`). With several tabs open, finding the current one is genuinely tiring.
2. **Short-titled tabs shrink to slivers.** Tabs are content-sized with `max-width: 200px` but no `min-width`, so a codex tab titled "usage" renders much narrower than its neighbors and reads as a different kind of control.

## Changes

- `.chrome-tab.active` gets a **2px top accent bar** (`box-shadow: inset 0 2px 0 0 var(--accent)`). Box-shadow survives the glass/carbon background strip, so this is the first active cue that works in every shape. sharp/panel keep their existing 1px accent variant via their higher-specificity rules; slab keeps its directional-light shadow.
- `.chrome-tab` gets `min-width: 120px`. Long titles still content-size up to the 200px cap.
- Comments in `CenterPanel.css` / `global.css` updated to describe the new behavior.

## Verification

`npm run build` green. Visual check recommended across shapes (especially glass) before merge.