### PR TITLE
feat(agent): add copy-last-response for claude/codex/kimi/hermes tabs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,4 @@ WebView2 对 `navigator.clipboard.*` 和 `document.execCommand('copy'|'paste')` 
 - **CF Worker 路由**：`coffeecli.com/version.json` 打到 Web-Home 静态；`coffeecli.com/download/<platform>` 走 Worker 重定向到 GitHub Releases
 - **PTY 锁死根因 #1 已修**（v0.6.1）：child watcher 线程；若复现视为根因 #2（emit/channel backpressure），看 `src/terminal.rs` reader 线程
 - **Hook forwarder 纪律**（v3.2.5+）：`__hook` 全路径 exit 0；`argv[1]` 以 `__` 开头但不认识的子命令也 exit 0（不起 GUI），防止"新配置 + 旧 exe"时 hook 报 exit 1。Claude hook 条目按 Git Bash 是否可探测写两种形态（`claude_hook_entry`）：有 Git Bash → `"shell": "bash"` + 引号命令；没有 → `"shell": "powershell"` + `& "..." __hook`——Windows 上 Claude 检测不到 Git Bash 会 fallback PowerShell，而 PowerShell 把引号开头的命令串当表达式直接 ParserError exit 1。排查 hook 问题用 `COFFEE_HOOK_DEBUG=1`，日志在 `~/.coffee-cli/hooks/hook-debug.log`
+- **Hook 载荷还承载 session 元数据**（v3.2.5+）：forwarder 会把 `session_id` / `transcript_path` / `cwd` 一并 post（有就带），hook server 缓存在 `SESSION_META`，`get_last_agent_reply` 命令（复制最后回复功能）靠它定位 transcript，不要删这些字段

--- a/scripts/coffee-cli-hermes-plugin.py
+++ b/scripts/coffee-cli-hermes-plugin.py
@@ -53,8 +53,28 @@ def _post(payload: dict) -> None:
         pass
 
 
+def _session_token(kwargs: dict):
+    """Best-effort extraction of the Hermes session token from hook kwargs.
+
+    The key name isn't documented; probe the likely shapes and only
+    return when we actually find something. Coffee CLI uses it to read
+    the session back from state.db for the copy-last-response feature.
+    """
+    for key in ("session_id", "session_token", "token", "session"):
+        v = kwargs.get(key)
+        if isinstance(v, str) and v:
+            return v
+        if v is not None and hasattr(v, "id"):
+            return str(v.id)
+    return None
+
+
 def _on_session_start(**kwargs):
-    _post({"status": "idle", "event": "on_session_start"})
+    payload = {"status": "idle", "event": "on_session_start", "cwd": os.getcwd()}
+    token = _session_token(kwargs)
+    if token:
+        payload["session_id"] = token
+    _post(payload)
 
 
 def _pre_llm_call(**kwargs):

--- a/src-ui/src/components/center/CenterPanel.tsx
+++ b/src-ui/src/components/center/CenterPanel.tsx
@@ -106,7 +106,7 @@ interface RemoteHistoryItem {
   user: string;
 }
 import { isTauri, commands } from '../../tauri';
-import { getToolDisplayName } from '../../lib/tool-info';
+import { getToolDisplayName, TAB_STATUS_TOOLS } from '../../lib/tool-info';
 import { useT } from '../../i18n/useT';
 import './CenterPanel.css';
 
@@ -422,17 +422,8 @@ const VALID_PIN_KEYS = new Set<string>([
   'installer', 'four-split', 'three-split', 'two-split',
 ]);
 
-// Tabs that show the status-grid ("Dynamic Island") indicator: every AI CLI.
-// Hook-wired tools (claude/codex/opencode/mimocode/hermes/kimicode) drive it
-// live off session.agentStatus; the rest have no status bus and sit at
-// static 'idle' green — the "fake island" baseline so every AI-CLI tab reads
-// consistently.
-// Non-CLI tabs (terminal/remote/history/splits/installer) get no indicator.
-const TAB_STATUS_TOOLS = new Set<string>([
-  'claude', 'codex', 'grok', 'opencode', 'mimocode', 'hermes',
-  'antigravity', 'qwen', 'openclaw',
-  'pi', 'crush', 'aider', 'kimicode', 'goose', 'copilot',
-]);
+// TAB_STATUS_TOOLS moved to lib/tool-info.ts (also read by TierTerminal's
+// "copy last reply" affordance — see there for the shared definition).
 
 export function CenterPanel() {
   const { state, dispatch } = useAppState();
@@ -1191,7 +1182,7 @@ export function CenterPanel() {
       case 'antigravity': return { icon: <SvgAntigravity />, title: cwd ?? getToolDisplayName('antigravity'), tooltip: pathTip };
       // Directory-aware tabs (icon + cwd basename). Pi and the T3 set
       // (Crush/Aider/Goose/Copilot) are hookless — no real status bus, so
-      // they get the static "fake" island via TAB_STATUS_TOOLS below.
+      // they get the static "fake" island via TAB_STATUS_TOOLS (lib/tool-info).
       // Kimi Code renders the same shape but is hook-wired (T1): its
       // island is live off session.agentStatus.
       case 'pi': return { icon: <SvgPi />, title: cwd ?? getToolDisplayName('pi'), tooltip: pathTip };

--- a/src-ui/src/components/center/TierTerminal.css
+++ b/src-ui/src/components/center/TierTerminal.css
@@ -349,4 +349,40 @@
     background: var(--border);
 }
 
+/* ─── Copy-last-reply pill ───────────────────────────────────
+   Floating bottom-right inside the terminal. Semi-transparent pill so
+   the xterm content behind it still hints through; colors all come
+   from theme variables like .term-ctx-menu above. Buttons aren't
+   matched by the glass/carbon nuclear :not() allowlist (it only lists
+   div/section/aside/…), so no glass opt-out is needed — the
+   translucent bg coordinates with the glass terminal as-is. */
+.term-copy-reply {
+    position: absolute;
+    right: 12px;
+    bottom: 12px;
+    z-index: 20; /* above .tier-xterm-wrap (1), below the splash (100) */
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 10px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-app) 72%, transparent);
+    color: var(--text-2);
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+    user-select: none;
+}
+
+.term-copy-reply:hover {
+    background: var(--bg-hover);
+    color: var(--text-1);
+}
+
+.term-copy-reply--copied {
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
 

--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -27,7 +27,7 @@ import { onWindowForeground } from '../../lib/window-focus-filter';
 import { commands } from '../../tauri';
 import { useAppDispatch, useAppState, type ToolType, type ThemeColor } from '../../store/app-state';
 import { useT } from '../../i18n/useT';
-import { getToolDisplayName } from '../../lib/tool-info';
+import { getToolDisplayName, COPY_REPLY_TOOLS } from '../../lib/tool-info';
 import '@xterm/xterm/css/xterm.css';
 import './TierTerminal.css';
 
@@ -211,10 +211,14 @@ export const detachedSessions = new Set<string>();
 
 interface CtxMenu { x: number; y: number; hasSelection: boolean; }
 
-function TermContextMenu({ menu, onClose, onCopy, onPaste, onSelectAll }: {
+function TermContextMenu({ menu, onClose, onCopy, onCopyReply, onPaste, onSelectAll }: {
   menu: CtxMenu;
   onClose: () => void;
   onCopy: () => void;
+  /** "Copy last reply" — only passed for tabs whose transcripts the
+      backend can read back (COPY_REPLY_TOOLS);
+   *  omitted for raw shells / split panes, which hide the item. */
+  onCopyReply?: () => void;
   onPaste: () => void;
   onSelectAll: () => void;
 }) {
@@ -242,7 +246,7 @@ function TermContextMenu({ menu, onClose, onCopy, onPaste, onSelectAll }: {
 
   // Clamp to viewport so menu never overflows off-screen
   const left = Math.min(menu.x, window.innerWidth  - 164);
-  const top  = Math.min(menu.y, window.innerHeight - 116);
+  const top  = Math.min(menu.y, window.innerHeight - 148);
 
   return createPortal(
     <div ref={ref} className="term-ctx-menu" style={{ left, top }}>
@@ -252,6 +256,14 @@ function TermContextMenu({ menu, onClose, onCopy, onPaste, onSelectAll }: {
       >
         <span>{t('menu.copy')}</span><kbd>{mod}+C</kbd>
       </button>
+      {onCopyReply && (
+        <button
+          className="term-ctx-item"
+          onMouseDown={(e) => { e.preventDefault(); onCopyReply(); }}
+        >
+          <span>{t('term.copy_last_reply')}</span>
+        </button>
+      )}
       <button
         className="term-ctx-item"
         onMouseDown={(e) => { e.preventDefault(); onPaste(); }}
@@ -505,6 +517,40 @@ function TierTerminalImpl({
   // ── Terminal context menu ────────────────────────────────────────────────
   const [ctxMenu, setCtxMenu] = useState<CtxMenu | null>(null);
   const closeCtxMenu = useCallback(() => setCtxMenu(null), []);
+
+  // ── Copy last reply ──────────────────────────────────────────────────────
+  // Flash state for the floating pill + context-menu item: 'copied' /
+  // 'empty' show for 1.5s, then revert to the default label. One shared
+  // timer — a rapid second click just restarts the window.
+  const [copyReplyFlash, setCopyReplyFlash] = useState<'copied' | 'empty' | null>(null);
+  const copyReplyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (copyReplyTimerRef.current) clearTimeout(copyReplyTimerRef.current);
+  }, []);
+  const copyLastReply = useCallback(async () => {
+    if (copyReplyTimerRef.current) clearTimeout(copyReplyTimerRef.current);
+    try {
+      const text = await commands.getLastAgentReply(sessionId);
+      await clipboardWrite(text);
+      setCopyReplyFlash('copied');
+    } catch {
+      // Backend rejects on every failure mode (no reply captured yet
+      // included) — one message covers them all.
+      setCopyReplyFlash('empty');
+    }
+    copyReplyTimerRef.current = setTimeout(() => setCopyReplyFlash(null), 1500);
+  }, [sessionId]);
+
+  // Pill visibility: only tools whose transcripts the backend can read
+  // back (COPY_REPLY_TOOLS), and only once the agent is back to idle —
+  // the reply is complete then. Hookless tools have no agentStatus; they
+  // sit at the same implicit 'idle' baseline as the island. Split-grid
+  // panes (`<tabId>::pane-N`) don't resolve to a tab-level session, so
+  // they get no pill — the backend reply cache is keyed per tab.
+  const tabSession = _appState.terminals.find((s) => s.id === sessionId);
+  const showCopyReply = !!tabSession
+    && COPY_REPLY_TOOLS.has(tabSession.tool as string)
+    && (tabSession.agentStatus ?? 'idle') === 'idle';
 
   const t = useT();
 
@@ -1913,6 +1959,31 @@ function TierTerminalImpl({
         <div ref={termRef} className={`tier-xterm${isRawShell ? ' raw-shell' : ''}`} />
       </div>
 
+      {/* Copy-last-reply pill — bottom-right of the terminal, AI-CLI tabs
+          at idle only (see showCopyReply). mousedown is swallowed so
+          clicking it never yanks focus out of xterm. */}
+      {showCopyReply && (
+        <button
+          className={`term-copy-reply${copyReplyFlash ? ` term-copy-reply--${copyReplyFlash}` : ''}`}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={copyLastReply}
+        >
+          {copyReplyFlash === 'copied' ? (
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="20 6 9 17 4 12"/>
+            </svg>
+          ) : (
+            /* Copy glyph — same rect+path pair as SessionContextMenu's
+               "copy full path" icon. */
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
+              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+            </svg>
+          )}
+          <span>{copyReplyFlash === 'copied' ? t('term.copied') : copyReplyFlash === 'empty' ? t('term.no_reply') : t('term.copy_last_reply')}</span>
+        </button>
+      )}
+
       {/* Terminal right-click context menu */}
       {ctxMenu && (
         <TermContextMenu
@@ -1923,6 +1994,9 @@ function TierTerminalImpl({
             if (text) clipboardWrite(text);
             closeCtxMenu();
           }}
+          onCopyReply={tabSession && COPY_REPLY_TOOLS.has(tabSession.tool as string)
+            ? () => { copyLastReply(); closeCtxMenu(); }
+            : undefined}
           onPaste={async () => {
             // Image-first paste (issue #89), then text. Backend clipboard
             // read (arboard) avoids the WebView2 permission prompt (issue #96).

--- a/src-ui/src/i18n/de.ts
+++ b/src-ui/src/i18n/de.ts
@@ -22,6 +22,11 @@ export const de = {
   'menu.copy_resume_command': 'Befehl zum Fortsetzen kopieren',
   'menu.copy_full_path': 'Vollständigen Pfad kopieren',
 
+  // Terminal
+  'term.copy_last_reply': 'Letzte Antwort kopieren',
+  'term.copied': 'Kopiert',
+  'term.no_reply': 'Noch keine Antwort zum Kopieren',
+
 
   // Tools
   'tool.terminal': 'Terminal',

--- a/src-ui/src/i18n/en.ts
+++ b/src-ui/src/i18n/en.ts
@@ -23,6 +23,11 @@ export const en = {
   'menu.copy_resume_command': 'Copy resume command',
   'menu.copy_full_path': 'Copy full path',
 
+  // Terminal
+  'term.copy_last_reply': 'Copy last reply',
+  'term.copied': 'Copied',
+  'term.no_reply': 'No reply to copy yet',
+
 
   // Tools
   'tool.terminal': 'Terminal',

--- a/src-ui/src/i18n/es.ts
+++ b/src-ui/src/i18n/es.ts
@@ -22,6 +22,11 @@ export const es = {
   'menu.copy_resume_command': 'Copiar comando de reanudación',
   'menu.copy_full_path': 'Copiar ruta completa',
 
+  // Terminal
+  'term.copy_last_reply': 'Copiar última respuesta',
+  'term.copied': 'Copiado',
+  'term.no_reply': 'Aún no hay respuesta para copiar',
+
 
   // Tools
   'tool.terminal': 'Terminal',

--- a/src-ui/src/i18n/fr.ts
+++ b/src-ui/src/i18n/fr.ts
@@ -22,6 +22,11 @@ export const fr = {
   'menu.copy_resume_command': 'Copier la commande de reprise',
   'menu.copy_full_path': 'Copier le chemin complet',
 
+  // Terminal
+  'term.copy_last_reply': 'Copier la dernière réponse',
+  'term.copied': 'Copié',
+  'term.no_reply': 'Aucune réponse à copier pour le moment',
+
 
   // Tools
   'tool.terminal': 'Terminal',

--- a/src-ui/src/i18n/ja.ts
+++ b/src-ui/src/i18n/ja.ts
@@ -22,6 +22,11 @@ export const ja = {
   'menu.copy_resume_command': '再開コマンドをコピー',
   'menu.copy_full_path': '完全パスをコピー',
 
+  // Terminal
+  'term.copy_last_reply': '最後の返信をコピー',
+  'term.copied': 'コピーしました',
+  'term.no_reply': 'コピーできる返信がまだありません',
+
 
   // Tools
   'tool.terminal': 'ターミナル',

--- a/src-ui/src/i18n/ko.ts
+++ b/src-ui/src/i18n/ko.ts
@@ -22,6 +22,11 @@ export const ko = {
   'menu.copy_resume_command': '재개 명령 복사',
   'menu.copy_full_path': '전체 경로 복사',
 
+  // Terminal
+  'term.copy_last_reply': '마지막 답변 복사',
+  'term.copied': '복사됨',
+  'term.no_reply': '아직 복사할 답변이 없습니다',
+
 
   // Tools
   'tool.terminal': '터미널',

--- a/src-ui/src/i18n/pt.ts
+++ b/src-ui/src/i18n/pt.ts
@@ -22,6 +22,11 @@ export const pt = {
   'menu.copy_resume_command': 'Copiar comando de retomada',
   'menu.copy_full_path': 'Copiar caminho completo',
 
+  // Terminal
+  'term.copy_last_reply': 'Copiar última resposta',
+  'term.copied': 'Copiado',
+  'term.no_reply': 'Ainda não há resposta para copiar',
+
 
   // Tools
   'tool.terminal': 'Terminal',

--- a/src-ui/src/i18n/ru.ts
+++ b/src-ui/src/i18n/ru.ts
@@ -22,6 +22,11 @@ export const ru = {
   'menu.copy_resume_command': 'Копировать команду возобновления',
   'menu.copy_full_path': 'Копировать полный путь',
 
+  // Terminal
+  'term.copy_last_reply': 'Копировать последний ответ',
+  'term.copied': 'Скопировано',
+  'term.no_reply': 'Пока нет ответа для копирования',
+
 
   // Tools
   'tool.terminal': 'Терминал',

--- a/src-ui/src/i18n/vi.ts
+++ b/src-ui/src/i18n/vi.ts
@@ -23,6 +23,11 @@ export const vi = {
   'menu.copy_resume_command': 'Sao chép lệnh tiếp tục',
   'menu.copy_full_path': 'Sao chép đường dẫn đầy đủ',
 
+  // Terminal
+  'term.copy_last_reply': 'Sao chép phản hồi cuối',
+  'term.copied': 'Đã sao chép',
+  'term.no_reply': 'Chưa có phản hồi để sao chép',
+
 
   // Tools
   'tool.terminal': 'Terminal',

--- a/src-ui/src/i18n/zh-CN.ts
+++ b/src-ui/src/i18n/zh-CN.ts
@@ -22,6 +22,11 @@ export const zhCN = {
   'menu.copy_resume_command': '复制恢复命令',
   'menu.copy_full_path': '复制完整路径',
 
+  // Terminal
+  'term.copy_last_reply': '复制最后回复',
+  'term.copied': '已复制',
+  'term.no_reply': '还没有可复制的回复',
+
 
   // Tools
   'tool.terminal': '终端',

--- a/src-ui/src/i18n/zh-TW.ts
+++ b/src-ui/src/i18n/zh-TW.ts
@@ -22,6 +22,11 @@ export const zhTW = {
   'menu.copy_resume_command': '複製恢復命令',
   'menu.copy_full_path': '複製完整路徑',
 
+  // Terminal
+  'term.copy_last_reply': '複製最後回覆',
+  'term.copied': '已複製',
+  'term.no_reply': '還沒有可複製的回覆',
+
 
   // Tools
   'tool.terminal': '終端機',

--- a/src-ui/src/lib/tool-info.ts
+++ b/src-ui/src/lib/tool-info.ts
@@ -47,3 +47,24 @@ export async function loadToolInfo(): Promise<void> {
 export function getToolDisplayName(id: string): string {
   return cache?.get(id) ?? id;
 }
+
+// Tabs that show the status-grid ("Dynamic Island") indicator: every AI CLI.
+// Hook-wired tools (claude/codex/opencode/mimocode/hermes/kimicode) drive it
+// live off session.agentStatus; the rest have no status bus and sit at
+// static 'idle' green — the "fake island" baseline so every AI-CLI tab reads
+// consistently. Non-CLI tabs (terminal/remote/history/splits/installer) get
+// no indicator.
+export const TAB_STATUS_TOOLS = new Set<string>([
+  'claude', 'codex', 'grok', 'opencode', 'mimocode', 'hermes',
+  'antigravity', 'qwen', 'openclaw',
+  'pi', 'crush', 'aider', 'kimicode', 'goose', 'copilot',
+]);
+
+// Tools whose last reply can be read back from an on-disk transcript —
+// gates TierTerminal's "copy last reply" button / context-menu item.
+// Backend: get_last_agent_reply in src/server.rs (claude transcript_path,
+// codex rollout, kimi wire.jsonl, hermes state.db). Other AI CLIs have no
+// transcript reader yet, so they don't get the button.
+export const COPY_REPLY_TOOLS = new Set<string>([
+  'claude', 'codex', 'kimicode', 'hermes',
+]);

--- a/src-ui/src/tauri.ts
+++ b/src-ui/src/tauri.ts
@@ -132,6 +132,13 @@ export const commands = {
   tierTerminalResize: (sessionId: string, cols: number, rows: number) =>
     invoke<void>('tier_terminal_resize', { sessionId, cols, rows }),
 
+  /** Last agent reply for a tab — backs the "Copy last reply" pill and
+   *  context-menu item. Rejects when the tab has no captured reply yet
+   *  (or any backend error); the frontend shows one "no reply yet"
+   *  message for every failure mode. */
+  getLastAgentReply: (tabId: string) =>
+    invoke<string>('get_last_agent_reply', { tabId }),
+
   /** Notify the Rust backend that the window's visibility changed.
    *  When hidden=true, every per-session worker thread (ticker, emitter)
    *  widens its sleep / coalesce window so a backgrounded Coffee CLI

--- a/src/hook_forwarder.rs
+++ b/src/hook_forwarder.rs
@@ -114,7 +114,7 @@ fn forward_claude() -> Option<()> {
         .to_string();
     let status = map_claude_status(&data, &event)?;
 
-    let ok = post(ctx.port, &ctx.tab_id, &ctx.tool, &status, &event);
+    let ok = post(ctx.port, &ctx.tab_id, &ctx.tool, &status, &event, Some(&data));
     debug_log(&format!(
         "__hook: event={} status={} post={}",
         event,
@@ -173,7 +173,7 @@ fn forward_codex(args: &[String]) -> Option<()> {
         .to_string();
     let status = map_codex_status(&event)?;
 
-    post(ctx.port, &ctx.tab_id, &ctx.tool, &status, &event);
+    post(ctx.port, &ctx.tab_id, &ctx.tool, &status, &event, Some(&data));
     Some(())
 }
 
@@ -201,7 +201,7 @@ fn forward_codex_hook() -> Option<()> {
         .to_string();
     let status = map_codex_hook_status(&event)?;
 
-    post(ctx.port, &ctx.tab_id, &ctx.tool, &status, &event);
+    post(ctx.port, &ctx.tab_id, &ctx.tool, &status, &event, Some(&data));
     Some(())
 }
 
@@ -236,7 +236,7 @@ fn forward_kimi() -> Option<()> {
     // Stop/StopFailure fire, and let the frontend 30s auto-idle cover a
     // real turn end. mid-turn green is worse than a late green.
     if let Some(status) = map_kimi_status(&event) {
-        post(ctx.port, &ctx.tab_id, &ctx.tool, status, &event);
+        post(ctx.port, &ctx.tab_id, &ctx.tool, status, &event, Some(&data));
     }
     Some(())
 }
@@ -315,13 +315,32 @@ fn map_codex_status(event: &str) -> Option<String> {
 /// One TCP connection per event to the loopback hook server. Every error is
 /// swallowed — the forwarder must never block the agent. Returns whether the
 /// send succeeded (for the COFFEE_HOOK_DEBUG trace only).
-fn post(port: u16, tab_id: &str, tool: &str, status: &str, event: &str) -> bool {
-    let payload = json!({
+///
+/// `meta` is the tool's raw hook payload when available: `session_id` /
+/// `transcript_path` / `cwd` are lifted into the posted JSON so the hook
+/// server can map tab → transcript for the copy-last-response feature.
+/// Tools whose payloads lack those keys simply contribute nothing.
+fn post(
+    port: u16,
+    tab_id: &str,
+    tool: &str,
+    status: &str,
+    event: &str,
+    meta: Option<&Value>,
+) -> bool {
+    let mut payload = json!({
         "tab_id": tab_id,
         "tool": tool,
         "status": status,
         "event": event,
     });
+    if let Some(m) = meta {
+        for key in ["session_id", "transcript_path", "cwd"] {
+            if let Some(v) = m.get(key).and_then(|v| v.as_str()) {
+                payload[key] = json!(v);
+            }
+        }
+    }
     send(port, &payload).is_ok()
 }
 

--- a/src/hook_server.rs
+++ b/src/hook_server.rs
@@ -14,10 +14,14 @@
 //       `{tab_id, tool, status, event}` → emit `agent-status` event
 //       to the frontend's tab indicators.
 //
+// Payloads may also carry `session_id` / `transcript_path` / `cwd` —
+// cached per tab in SESSION_META and used by the `get_last_agent_reply`
+// command to locate the tab's transcript file.
+//
 // File-edit attribution per AI tool was removed in v2.7.x —
 // ChangesBoard is now sourced from a folder snapshot diff
 // (`compute_folder_stats` Tauri command, tool-agnostic by design).
-// `path` / `action` / `cwd` fields are kept in the wire payload for
+// `path` / `action` fields are kept in the wire payload for
 // backward compat with installed hook scripts; they are ignored.
 
 use serde::{Deserialize, Serialize};
@@ -38,6 +42,61 @@ pub struct HookPayload {
     /// Hook event name (Claude: PostToolUse / Notification / Stop;
     /// Codex: agent-turn-complete; OpenCode: session.status / etc.).
     pub event: Option<String>,
+    /// Session identifier, when the tool's hook payload carries one
+    /// (Claude/Codex/Kimi: session_id; Hermes plugin: session token).
+    /// Cached in SESSION_META so `get_last_agent_reply` can locate the
+    /// tab's transcript without guessing from the cwd.
+    pub session_id: Option<String>,
+    /// Direct path to the session transcript file (Claude hooks send
+    /// `transcript_path` in the stdin JSON). Most precise locator — used
+    /// first when present.
+    pub transcript_path: Option<String>,
+    /// Working directory of the agent session — fallback locator for
+    /// tools whose transcripts are found by cwd match (Codex rollouts).
+    pub cwd: Option<String>,
+}
+
+/// Per-tab session metadata, upserted from hook payloads that carry it.
+/// Read by the `get_last_agent_reply` Tauri command (src/server.rs) to
+/// find the tab's transcript file / session token.
+#[derive(Debug, Clone, Default)]
+pub struct SessionMeta {
+    pub tool: String,
+    pub session_id: Option<String>,
+    pub transcript_path: Option<String>,
+    pub cwd: Option<String>,
+}
+
+static SESSION_META: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<String, SessionMeta>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Snapshot the session metadata for a tab. None when no hook carrying
+/// metadata has fired for this tab yet.
+pub fn session_meta(tab_id: &str) -> Option<SessionMeta> {
+    SESSION_META.lock().ok()?.get(tab_id).cloned()
+}
+
+/// Upsert metadata from a payload — any field present overwrites, absent
+/// fields keep their previous value (hooks don't all carry the same keys).
+fn update_session_meta(payload: &HookPayload) {
+    if payload.session_id.is_none() && payload.transcript_path.is_none() && payload.cwd.is_none() {
+        return;
+    }
+    let Ok(mut map) = SESSION_META.lock() else { return };
+    let meta = map.entry(payload.tab_id.clone()).or_insert_with(|| SessionMeta {
+        tool: payload.tool.clone(),
+        ..Default::default()
+    });
+    meta.tool = payload.tool.clone();
+    if payload.session_id.is_some() {
+        meta.session_id = payload.session_id.clone();
+    }
+    if payload.transcript_path.is_some() {
+        meta.transcript_path = payload.transcript_path.clone();
+    }
+    if payload.cwd.is_some() {
+        meta.cwd = payload.cwd.clone();
+    }
 }
 
 /// Frontend payload for the `agent-status` Tauri event — unchanged
@@ -109,6 +168,7 @@ async fn handle_conn(app: AppHandle, socket: tokio::net::TcpStream) {
 /// path remains — see file-level doc for why per-tool file-edit
 /// attribution was removed.
 fn dispatch(app: &AppHandle, payload: HookPayload) {
+    update_session_meta(&payload);
     if let Some(status) = payload.status.as_deref() {
         let evt = AgentStatusEvent {
             tab_id: payload.tab_id.clone(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -1811,15 +1811,12 @@ fn parse_qwen_session_jsonl(file_path: &std::path::Path) -> Option<SavedSession>
     })
 }
 
-#[tauri::command]
-fn read_native_session(file_path: String) -> Result<String, String> {
-    let path = std::path::Path::new(&file_path);
-
-    // Only allow .jsonl / .json files
-    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-    if ext != "jsonl" && ext != "json" {
-        return Err("Only .jsonl and .json files are allowed".to_string());
-    }
+/// Canonicalize `file_path` and verify it sits under a known agent data
+/// directory. Shared by `read_native_session` (frontend-supplied paths) and
+/// `get_last_agent_reply` (hook-supplied transcript paths) so both get the
+/// same `..`/symlink-traversal screening before any bytes are read.
+fn canonical_agent_data_path(file_path: &str) -> Result<std::path::PathBuf, String> {
+    let path = std::path::Path::new(file_path);
 
     // Canonicalize to resolve any `..` or symlink traversal
     let canonical_raw = path.canonicalize().map_err(|e| format!("Invalid path: {e}"))?;
@@ -1883,6 +1880,20 @@ fn read_native_session(file_path: String) -> Result<String, String> {
         return Err("Access denied: path is outside allowed agent data directories".to_string());
     }
 
+    Ok(canonical)
+}
+
+#[tauri::command]
+fn read_native_session(file_path: String) -> Result<String, String> {
+    let path = std::path::Path::new(&file_path);
+
+    // Only allow .jsonl / .json files
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    if ext != "jsonl" && ext != "json" {
+        return Err("Only .jsonl and .json files are allowed".to_string());
+    }
+
+    let canonical = canonical_agent_data_path(&file_path)?;
     std::fs::read_to_string(&canonical).map_err(|e| e.to_string())
 }
 
@@ -2971,6 +2982,488 @@ fn read_hermes_session(session_token: String) -> Result<String, String> {
     Ok(out)
 }
 
+// ─── Last Agent Reply (copy-last-response) ─────────────────────────────────
+//
+// `get_last_agent_reply` returns the tab's most recent assistant reply as
+// plain text (for the frontend's "copy last response" action). The hook
+// server caches per-tab session metadata (`hook_server::session_meta`) —
+// transcript path for Claude, session id / cwd for the rest — and each
+// tool branch below locates the transcript from that, then scans the file
+// BACKWARDS for the last assistant text. Transcripts grow to tens of MB,
+// so nothing here reads a whole file: `TailLines` pulls 64 KB chunks off
+// the end until a matching row shows up (a few hundred KB in practice),
+// capped at REPLY_SCAN_MAX_BYTES.
+
+/// How far back from EOF to scan for an assistant row before giving up.
+/// Assistant rows sit between tool_result rows, so the hit usually lands
+/// within a few hundred KB; 8 MB covers pathological tool-output spam.
+const REPLY_SCAN_MAX_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Reverse line reader over the tail of a file. Reads backwards in 64 KB
+/// seeks (never loading the whole transcript) and yields complete lines
+/// from last to first. Stops once `max_bytes` have been pulled; the partial
+/// line straddling the scan boundary is dropped, so callers must tolerate
+/// missing the oldest line in the window.
+struct TailLines {
+    file: std::fs::File,
+    /// Offset of the first byte not yet pulled into `carry`.
+    next_read_end: u64,
+    /// Total bytes read so far (capped at `max_bytes`).
+    read: u64,
+    max_bytes: u64,
+    /// Undispensed bytes, oldest first. May hold a partial leading line
+    /// until `next_read_end` reaches 0.
+    carry: Vec<u8>,
+}
+
+impl TailLines {
+    fn open(path: &std::path::Path, max_bytes: u64) -> std::io::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let len = file.metadata()?.len();
+        Ok(Self { file, next_read_end: len, read: 0, max_bytes, carry: Vec::new() })
+    }
+
+    /// Pull older 64 KB chunks into `carry` until it holds at least one
+    /// newline, the file start is reached, or the byte cap is hit.
+    fn fill(&mut self) -> std::io::Result<()> {
+        use std::io::{Read, Seek, SeekFrom};
+        const CHUNK: u64 = 64 * 1024;
+        while !self.carry.contains(&b'\n') && self.next_read_end > 0 && self.read < self.max_bytes {
+            let size = CHUNK.min(self.next_read_end).min(self.max_bytes - self.read);
+            if size == 0 {
+                break;
+            }
+            let start = self.next_read_end - size;
+            self.file.seek(SeekFrom::Start(start))?;
+            let mut chunk = vec![0u8; size as usize];
+            self.file.read_exact(&mut chunk)?;
+            chunk.extend_from_slice(&self.carry);
+            self.carry = chunk;
+            self.next_read_end = start;
+            self.read += size;
+        }
+        Ok(())
+    }
+}
+
+impl Iterator for TailLines {
+    type Item = String;
+
+    fn next(&mut self) -> Option<String> {
+        loop {
+            if let Some(pos) = self.carry.iter().rposition(|&b| b == b'\n') {
+                let mut line = self.carry.split_off(pos + 1);
+                self.carry.pop(); // drop the '\n' itself
+                if line.last() == Some(&b'\r') {
+                    line.pop();
+                }
+                return Some(String::from_utf8_lossy(&line).into_owned());
+            }
+            if self.fill().is_err() {
+                return None;
+            }
+            if self.carry.contains(&b'\n') {
+                continue;
+            }
+            if self.next_read_end == 0 {
+                // File start reached: `carry` is the first line.
+                if self.carry.is_empty() {
+                    return None;
+                }
+                let mut line = std::mem::take(&mut self.carry);
+                if line.last() == Some(&b'\r') {
+                    line.pop();
+                }
+                return Some(String::from_utf8_lossy(&line).into_owned());
+            }
+            // Byte cap hit mid-line: the partial oldest line is unusable.
+            return None;
+        }
+    }
+}
+
+/// Join the `text` of every text block in a message `content` array.
+/// Claude assistant blocks are `{"type":"text"}`, Codex `{"type":"output_text"}`;
+/// thinking / tool_use / input_text blocks are skipped. Mirrors the block
+/// handling in `parse_agent_jsonl` / `parse_codex_session_jsonl`.
+fn join_text_blocks(content: Option<&serde_json::Value>) -> String {
+    let Some(arr) = content.and_then(|c| c.as_array()) else {
+        return String::new();
+    };
+    arr.iter()
+        .filter(|b| matches!(b.get("type").and_then(|t| t.as_str()), Some("text") | Some("output_text")))
+        .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Separator- and (on Windows) case-insensitive cwd comparison. Hooks report
+/// `E:\proj` while session files may record `E:/proj`; treat them as equal.
+fn same_path(a: &str, b: &str) -> bool {
+    let norm = |s: &str| {
+        let s = s.replace('\\', "/");
+        let s = s.trim_end_matches('/');
+        #[cfg(windows)]
+        { s.to_lowercase() }
+        #[cfg(not(windows))]
+        { s.to_string() }
+    };
+    norm(a) == norm(b)
+}
+
+/// Normalize a raw agent reply for display/clipboard: strip ANSI escape
+/// sequences (same pattern as terminal.rs's output stripper), collapse runs
+/// of blank lines to a single blank line, trim the whole thing.
+fn clean_agent_reply(raw: &str) -> String {
+    static ANSI_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let re = ANSI_RE.get_or_init(|| {
+        regex::Regex::new(r"\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\].*?(?:\x07|\x1b\\)|\x1b.").unwrap()
+    });
+    let stripped = re.replace_all(raw, "");
+    let mut out = String::with_capacity(stripped.len());
+    let mut last_blank = true; // leading blanks collapse into the final trim
+    for line in stripped.lines() {
+        let line = line.trim_end();
+        if line.is_empty() {
+            if last_blank {
+                continue;
+            }
+            last_blank = true;
+        } else {
+            last_blank = false;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.trim().to_string()
+}
+
+/// Claude branch: the hook payload carries `transcript_path` pointing
+/// straight at the session JSONL. Screened through the same canonicalize +
+/// allowlist gate as `read_native_session` before reading.
+fn last_claude_reply(meta: &crate::hook_server::SessionMeta) -> Result<String, String> {
+    let transcript = meta
+        .transcript_path
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "no transcript path for tab yet".to_string())?;
+    let canonical = canonical_agent_data_path(transcript)?;
+    scan_claude_tail(&canonical)
+}
+
+/// Tail-scan a Claude transcript for the last assistant text. Assistant rows
+/// look like `{"type":"assistant","message":{"role":"assistant","content":[
+/// {"type":"text","text":...},{"type":"thinking",...},{"type":"tool_use",...}]}}`;
+/// the first row (from EOF) with at least one text block wins.
+fn scan_claude_tail(path: &std::path::Path) -> Result<String, String> {
+    let lines = TailLines::open(path, REPLY_SCAN_MAX_BYTES)
+        .map_err(|e| format!("open transcript: {e}"))?;
+    for line in lines {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else { continue };
+        if v.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+            continue;
+        }
+        // Sidechain rows are Task-subagent turns, not the tab's main reply.
+        if v.get("isSidechain").and_then(|b| b.as_bool()).unwrap_or(false) {
+            continue;
+        }
+        let Some(msg) = v.get("message") else { continue };
+        if msg.get("role").and_then(|r| r.as_str()) != Some("assistant") {
+            continue;
+        }
+        let text = join_text_blocks(msg.get("content"));
+        // Assistant turns with only thinking/tool_use blocks: keep scanning.
+        if !text.trim().is_empty() {
+            return Ok(text);
+        }
+    }
+    Err("no assistant text found in transcript tail".to_string())
+}
+
+/// Recursively collect `rollout-*.jsonl` under `~/.codex/sessions/<YYYY>/<MM>/<DD>/`
+/// with mtimes. Shallow tree (3 fixed levels), so a plain recursive walk is fine.
+fn collect_codex_rollouts(dir: &std::path::Path, out: &mut Vec<(std::time::SystemTime, std::path::PathBuf)>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_codex_rollouts(&path, out);
+        } else if entry.file_name().to_string_lossy().starts_with("rollout-")
+            && path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+        {
+            let mtime = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            out.push((mtime, path));
+        }
+    }
+}
+
+/// Codex branch: no direct transcript path in the notify payload, so locate
+/// the rollout by walking `~/.codex/sessions` newest-first and matching the
+/// first row's `session_meta.payload` against the tab's session id (exact)
+/// or cwd (see `parse_codex_session_jsonl` for the row schema). Then tail-scan
+/// that file for the last `response_item` assistant message.
+fn last_codex_reply(meta: &crate::hook_server::SessionMeta) -> Result<String, String> {
+    use std::io::BufRead;
+    let home = dirs::home_dir().ok_or_else(|| "no home dir".to_string())?;
+    let root = home.join(".codex").join("sessions");
+    let mut rollouts: Vec<(std::time::SystemTime, std::path::PathBuf)> = Vec::new();
+    collect_codex_rollouts(&root, &mut rollouts);
+    rollouts.sort_by(|a, b| b.0.cmp(&a.0));
+    // The tab's rollout is normally among the newest handful; cap the
+    // first-row probes so a huge archive can't stall the command.
+    rollouts.truncate(50);
+
+    for (_, path) in &rollouts {
+        let Ok(file) = std::fs::File::open(path) else { continue };
+        let Some(Ok(first)) = std::io::BufReader::new(file).lines().next() else { continue };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&first) else { continue };
+        if v.get("type").and_then(|t| t.as_str()) != Some("session_meta") {
+            continue;
+        }
+        let Some(payload) = v.get("payload") else { continue };
+        let id_match = meta.session_id.as_deref().is_some_and(|want| {
+            payload.get("session_id").and_then(|x| x.as_str()) == Some(want)
+                || payload.get("id").and_then(|x| x.as_str()) == Some(want)
+        });
+        // cwd match doubles as the fallback locator; sub-agent rollouts share
+        // the parent's cwd, so exclude them or they'd shadow the main session.
+        let cwd_match = meta.cwd.as_deref().is_some_and(|want| {
+            payload.get("cwd").and_then(|x| x.as_str()).is_some_and(|c| same_path(c, want))
+        }) && !is_codex_subagent_session(payload);
+        if !id_match && !cwd_match {
+            continue;
+        }
+        let lines = TailLines::open(path, REPLY_SCAN_MAX_BYTES)
+            .map_err(|e| format!("open rollout: {e}"))?;
+        for line in lines {
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else { continue };
+            if v.get("type").and_then(|t| t.as_str()) != Some("response_item") {
+                continue;
+            }
+            let Some(p) = v.get("payload") else { continue };
+            if p.get("type").and_then(|t| t.as_str()) != Some("message")
+                || p.get("role").and_then(|r| r.as_str()) != Some("assistant")
+            {
+                continue;
+            }
+            let text = join_text_blocks(p.get("content"));
+            if !text.trim().is_empty() {
+                return Ok(text);
+            }
+        }
+        return Err("no assistant text found in rollout tail".to_string());
+    }
+    Err("no codex rollout matches this tab".to_string())
+}
+
+/// Locate the tab's `<sessionDir>/agents/main/wire.jsonl`. Exact session-id
+/// lookup in `session_index.jsonl` first (same index `find_kimi_sessions`
+/// reads), then newest index entry whose workDir matches the tab's cwd, then
+/// a newest-mtime walk over `sessions/wd_*/session_*/agents/main/wire.jsonl`.
+fn locate_kimi_wire(
+    root: &std::path::Path,
+    meta: &crate::hook_server::SessionMeta,
+) -> Option<std::path::PathBuf> {
+    let wire_of = |dir: &std::path::Path| {
+        let w = dir.join("agents").join("main").join("wire.jsonl");
+        if w.is_file() { Some(w) } else { None }
+    };
+    if let Ok(index) = std::fs::read_to_string(root.join("session_index.jsonl")) {
+        let mut cwd_best: Option<(std::time::SystemTime, std::path::PathBuf)> = None;
+        for line in index.lines() {
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else { continue };
+            let session_id = v.get("sessionId").and_then(|x| x.as_str()).unwrap_or("");
+            let session_dir = v.get("sessionDir").and_then(|x| x.as_str()).unwrap_or("");
+            let work_dir = v.get("workDir").and_then(|x| x.as_str()).unwrap_or("");
+            if session_dir.is_empty() {
+                continue;
+            }
+            let dir = std::path::PathBuf::from(session_dir);
+            if meta.session_id.as_deref().is_some_and(|want| want == session_id) {
+                if let Some(w) = wire_of(&dir) {
+                    return Some(w);
+                }
+            }
+            if meta.cwd.as_deref().is_some_and(|want| !work_dir.is_empty() && same_path(work_dir, want)) {
+                let mtime = std::fs::metadata(dir.join("state.json"))
+                    .and_then(|m| m.modified())
+                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+                if cwd_best.as_ref().is_none_or(|(t, _)| mtime > *t) {
+                    cwd_best = Some((mtime, dir));
+                }
+            }
+        }
+        if let Some((_, dir)) = cwd_best {
+            if let Some(w) = wire_of(&dir) {
+                return Some(w);
+            }
+        }
+    }
+    // Fallback: newest wire.jsonl anywhere under sessions/wd_*/.
+    let mut best: Option<(std::time::SystemTime, std::path::PathBuf)> = None;
+    let Ok(wd_dirs) = std::fs::read_dir(root.join("sessions")) else { return None };
+    for wd in wd_dirs.flatten() {
+        let wd_path = wd.path();
+        if !wd_path.is_dir() {
+            continue;
+        }
+        let Ok(sess_dirs) = std::fs::read_dir(&wd_path) else { continue };
+        for sess in sess_dirs.flatten() {
+            let Some(w) = wire_of(&sess.path()) else { continue };
+            let mtime = std::fs::metadata(&w)
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            if best.as_ref().is_none_or(|(t, _)| mtime > *t) {
+                best = Some((mtime, w));
+            }
+        }
+    }
+    best.map(|(_, w)| w)
+}
+
+/// Kimi Code branch: wire.jsonl carries the assistant stream as
+/// `{"type":"context.append_loop_event","event":{"type":"content.part",
+/// "part":{"type":"text","text":...}}}` rows (thinking arrives as
+/// `part.type=="think"` — skipped). Tail-scan for the last text part; also
+/// accept the `context.append_message` assistant-row shape as a fallback.
+fn last_kimi_reply(meta: &crate::hook_server::SessionMeta) -> Result<String, String> {
+    let home = dirs::home_dir().ok_or_else(|| "no home dir".to_string())?;
+    let root = kimi_root(&home).ok_or_else(|| "kimi data root not found".to_string())?;
+    let wire = locate_kimi_wire(&root, meta)
+        .ok_or_else(|| "no kimi session found for this tab".to_string())?;
+    let lines = TailLines::open(&wire, REPLY_SCAN_MAX_BYTES)
+        .map_err(|e| format!("open wire.jsonl: {e}"))?;
+    for line in lines {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else { continue };
+        let row_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if row_type == "context.append_loop_event" {
+            let Some(event) = v.get("event") else { continue };
+            if event.get("type").and_then(|t| t.as_str()) != Some("content.part") {
+                continue;
+            }
+            let Some(part) = event.get("part") else { continue };
+            if part.get("type").and_then(|t| t.as_str()) != Some("text") {
+                continue;
+            }
+            if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                if !text.trim().is_empty() {
+                    return Ok(text.to_string());
+                }
+            }
+            continue;
+        }
+        if row_type == "context.append_message" {
+            let Some(msg) = v.get("message") else { continue };
+            if msg.get("role").and_then(|r| r.as_str()) != Some("assistant") {
+                continue;
+            }
+            let text = join_text_blocks(msg.get("content"));
+            if !text.trim().is_empty() {
+                return Ok(text);
+            }
+        }
+    }
+    Err("no assistant text found in wire.jsonl tail".to_string())
+}
+
+/// Hermes branch: query `state.db` directly (same read-only flags and
+/// content decoding as `read_hermes_session`). The tab's session token comes
+/// from the hook payload; when absent, fall back to the newest non-archived
+/// session whose cwd matches the tab's (mirrors `find_hermes_sessions_sqlite`'s
+/// row schema). NOTE: Hermes isn't installed on the dev machine — this path
+/// is verified by code review against the schema, not by a live run.
+fn last_hermes_reply(meta: &crate::hook_server::SessionMeta) -> Result<String, String> {
+    let home = dirs::home_dir().ok_or_else(|| "no home dir".to_string())?;
+    let db = hermes_state_db(&home)
+        .filter(|p| p.is_file())
+        .ok_or_else(|| "hermes state.db not found".to_string())?;
+    let conn = rusqlite::Connection::open_with_flags(
+        &db,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| format!("open hermes state.db: {e}"))?;
+
+    let session_id = match meta.session_id.as_deref().filter(|s| !s.is_empty()) {
+        Some(token) => token.to_string(),
+        None => {
+            let mut stmt = conn
+                .prepare("SELECT id, cwd FROM sessions WHERE archived = 0 ORDER BY started_at DESC LIMIT 50")
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map([], |row| {
+                    // Same tolerant id read as find_hermes_sessions_sqlite.
+                    let id: String = row
+                        .get::<_, String>(0)
+                        .or_else(|_| row.get::<_, i64>(0).map(|n| n.to_string()))?;
+                    let cwd: String = row.get::<_, Option<String>>(1).unwrap_or(None).unwrap_or_default();
+                    Ok((id, cwd))
+                })
+                .map_err(|e| e.to_string())?;
+            let mut found: Option<String> = None;
+            for row in rows.flatten() {
+                let (id, cwd) = row;
+                // Rows are newest-first: first cwd match wins; with no cwd
+                // on the tab, take the newest session outright.
+                match meta.cwd.as_deref() {
+                    Some(want) if same_path(&cwd, want) => {
+                        found = Some(id);
+                        break;
+                    }
+                    None => {
+                        found = Some(id);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            found.ok_or_else(|| "no hermes session matches this tab".to_string())?
+        }
+    };
+
+    let mut stmt = conn
+        .prepare("SELECT content FROM messages WHERE session_id = ?1 AND role = 'assistant' ORDER BY rowid DESC LIMIT 1")
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([&session_id], |row| row.get::<_, Option<String>>(0))
+        .map_err(|e| e.to_string())?;
+    for content in rows.flatten().flatten() {
+        let text = hermes_decode_content(&content);
+        if !text.trim().is_empty() {
+            return Ok(text);
+        }
+    }
+    Err("no assistant text found in hermes session".to_string())
+}
+
+#[tauri::command]
+async fn get_last_agent_reply(tab_id: String) -> Result<String, String> {
+    // Async command + spawn_blocking so the transcript tail-scan runs on the
+    // blocking thread pool — same pattern as get_native_history.
+    tauri::async_runtime::spawn_blocking(move || last_agent_reply_blocking(&tab_id))
+        .await
+        .map_err(|e| format!("reply task join failed: {e}"))?
+}
+
+fn last_agent_reply_blocking(tab_id: &str) -> Result<String, String> {
+    let meta = crate::hook_server::session_meta(tab_id)
+        .ok_or_else(|| "no session metadata for tab yet".to_string())?;
+    let raw = match meta.tool.as_str() {
+        "claude" => last_claude_reply(&meta),
+        "codex" => last_codex_reply(&meta),
+        "kimicode" | "kimi" => last_kimi_reply(&meta),
+        "hermes" => last_hermes_reply(&meta),
+        other => Err(format!("unsupported tool: {other}")),
+    }?;
+    let cleaned = clean_agent_reply(&raw);
+    if cleaned.is_empty() {
+        return Err("no assistant reply found".to_string());
+    }
+    Ok(cleaned)
+}
+
 #[tauri::command]
 async fn get_native_history() -> Result<Vec<SavedSession>, String> {
     // Async command + spawn_blocking so the file I/O runs on a dedicated
@@ -3789,6 +4282,7 @@ pub fn start_ui(pending_launch: Option<crate::launch::LaunchRequest>) -> anyhow:
             set_background_mode,
             set_session_active,
             get_native_history,
+            get_last_agent_reply,
             get_message_heatmap,
             read_native_session,
             read_opencode_session,
@@ -4496,6 +4990,87 @@ mod tests {
         let got = parse_agent_jsonl(&f, "claude", &std::collections::HashMap::new()).expect("mixed-array session kept");
         // Title comes from the real text block, not the injected tool_result.
         assert_eq!(got.name, "帮我把这个文件重构一下");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// TailLines yields complete lines last-to-first without loading the
+    /// whole file, and a generous byte cap still reaches the first line.
+    #[test]
+    fn tail_lines_reads_backwards_to_file_start() {
+        let dir = std::env::temp_dir().join(format!("coffee-cli-tail-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("t.jsonl");
+        // >64 KB so the reader must chain multiple chunks.
+        let mut content = String::new();
+        for i in 0..2000 {
+            content.push_str(&format!("{{\"n\":{},\"pad\":\"{}\"}}\n", i, "x".repeat(60)));
+        }
+        content.push_str("last-line-no-trailing-newline");
+        std::fs::write(&f, &content).unwrap();
+
+        let lines: Vec<String> = TailLines::open(&f, REPLY_SCAN_MAX_BYTES).unwrap().collect();
+        assert_eq!(lines.len(), 2001);
+        assert_eq!(lines[0], "last-line-no-trailing-newline");
+        assert!(lines[1].contains("\"n\":1999"));
+        assert!(lines[2000].contains("\"n\":0"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// With a small byte cap the scan stops mid-file and the partial line
+    /// straddling the boundary is dropped, not half-returned.
+    #[test]
+    fn tail_lines_respects_byte_cap() {
+        let dir = std::env::temp_dir().join(format!("coffee-cli-cap-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("t.jsonl");
+        let mut content = String::new();
+        for i in 0..100 {
+            content.push_str(&format!("line-{:04}-{}\n", i, "y".repeat(90)));
+        }
+        std::fs::write(&f, &content).unwrap();
+
+        let lines: Vec<String> = TailLines::open(&f, 1024).unwrap()
+            .filter(|l| !l.is_empty()) // trailing '\n' yields a final empty segment
+            .collect();
+        assert!(!lines.is_empty());
+        assert!(lines[0].starts_with("line-0099"));
+        // Every yielded line is complete — none starts mid-padding.
+        for l in &lines {
+            assert!(l.starts_with("line-"), "partial line leaked: {l}");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn clean_agent_reply_strips_ansi_and_collapses_blanks() {
+        let raw = "\u{1b}[32mok\u{1b}[0m done\n\n\n\nnext  \n\n";
+        assert_eq!(clean_agent_reply(raw), "ok done\n\nnext");
+        assert_eq!(clean_agent_reply("   \n\n  "), "");
+    }
+
+    /// End-to-end-ish: a Claude-shaped transcript whose tail is tool noise
+    /// yields the last assistant TEXT (skipping thinking/tool_use-only turns
+    /// and sidechain rows), through the cleaner.
+    #[test]
+    fn last_agent_reply_extracts_last_assistant_text() {
+        let dir = std::env::temp_dir().join(format!("coffee-cli-reply-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("s.jsonl");
+        write_jsonl(&f, &[
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}",
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"first reply\"}]}}",
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"...\"},{\"type\":\"text\",\"text\":\"second\\n\\n\\nreply\"}]}}",
+            // Sidechain (Task subagent) text must not win over the main reply.
+            "{\"type\":\"assistant\",\"isSidechain\":true,\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"subagent text\"}]}}",
+            // Tool-use-only assistant turn + tool_result noise at the tail.
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{}}]}}",
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"content\":\"ok\"}]}}",
+        ]);
+        let found = scan_claude_tail(&f).expect("assistant text found");
+        assert_eq!(clean_agent_reply(&found), "second\n\nreply");
         let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## What

A "copy last response" affordance for AI-CLI tabs (the Hermes TUI has one inline; Coffee can't draw inside the agent's own TUI, so this is the closest equivalent):

- **Floating pill** at the terminal pane's bottom-right, shown when the tab's tool is supported (claude / codex / kimicode / hermes) and the agent is idle (reply complete). Click → reply text on the clipboard, pill flashes "Copied".
- Same action in the terminal **right-click menu**.
- i18n for all 11 locales.

## How it gets the reply text — transcripts, not the terminal buffer

The hook channel already reaches every AI tab; this PR extends it instead of guessing reply boundaries in the xterm buffer:

- `hook_forwarder.rs` now lifts `session_id` / `transcript_path` / `cwd` from each tool's hook payload into the post (they were parsed and dropped); the Hermes plugin sends its session token + cwd.
- `hook_server.rs` caches them per tab in `SESSION_META` (upsert; wire format stays backward-compatible — unknown fields were already tolerated).
- New `get_last_agent_reply(tab_id)` command resolves the tab's transcript — claude `transcript_path` (allowlist-validated), codex rollout matched by session-id/cwd, kimi `wire.jsonl`, hermes `state.db` — and **tail-scans backwards** (64KB chunks, 8MB cap) for the last assistant text. Whole-transcript loads are avoided. ANSI stripped, blank runs collapsed; thinking/tool_use blocks skipped.

## Verification

- `cargo check` ✅, `cargo test` server module: 32 passed (incl. new tail-scan/extraction tests; the one failing `launch::` test is pre-existing on main, Windows env issue)
- `npm run build` ✅; clipboard rule check: no new `navigator.clipboard` / `plugin-clipboard-manager` hits outside `lib/clipboard.ts`
- Extraction validated against **real on-disk transcripts** for claude, codex, and kimi (script replaying the exact tail-scan logic hit genuine last-assistant text in each format)
- Hermes path is schema-reviewed only — Hermes isn't installed on the dev machine
- Not e2e-tested in a live dev instance: the dev build shares the single-instance lock with the production app that hosts this very session. Happy to add UI screenshots if you want them — let me know and I'll capture them on a separate login.

## Notes

- Split-grid panes don't get the pill (reply cache is tab-keyed).
- Tools without a transcript reader (qwen, grok, …) don't show the button — gated by `COPY_REPLY_TOOLS`.