### PR TITLE
fix(env): GUI 启动时完整继承登录 shell 环境，修复 .zshrc 导出变量在 PTY 标签页中全部丢失

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -125,30 +125,39 @@ fn main() -> Result<()> {
     //      toggle worked in Terminal.app (login shell) but not here.
     //
     // Fix: ask the user's login shell for its full environment ONCE at
-    // startup via a single `-ilc env` probe. PATH replaces the process
-    // PATH (with a sanity guard); every other variable is imported ONLY
-    // when absent from our process env — the launchd/GUI env always wins,
-    // we just fill gaps. PTY spawns inherit the process env (see the
-    // `std::env::vars()` loop in terminal.rs), so one probe here fixes
-    // every downstream tab and tool-detection `which`.
+    // startup via a single `-ilc` probe. The probe prints a sentinel
+    // marker line, then `env`; rc-file echo (motd banners, `echo` in
+    // .zshrc) lands BEFORE the marker and is discarded, so only the clean
+    // `env` output is parsed. PATH replaces the process PATH (with a
+    // sanity guard); every other variable is imported ONLY when absent
+    // from our process env — the launchd/GUI env always wins, we just fill
+    // gaps. PTY spawns inherit the process env (see the `std::env::vars()`
+    // loop in terminal.rs), so one probe here fixes every downstream tab
+    // and tool-detection `which`.
     //
     // We use `-ilc` (interactive + login) so both .zprofile/.bash_profile
     // AND .zshrc/.bashrc are sourced — matches what the user sees when
     // they open a fresh terminal window. `env` is an external command, so
     // fish works too (its exported PATH arrives colon-joined, no special
-    // casing needed).
+    // casing).
     #[cfg(not(target_os = "windows"))]
     unsafe {
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        // Sentinel-delimited `env` so rc-file echo (motd banners, `echo`
+        // in .zshrc) that lands AFTER the marker doesn't get folded into a
+        // previous variable's value. The marker is printed first, then the
+        // real `env` output; parse_env_dump slices at the marker.
+        let probe = format!("printf '{}\\n'; env", ENV_DUMP_MARKER);
         if let Ok(out) = std::process::Command::new(&shell)
-            .args(["-ilc", "env"])
+            .args(["-ilc", &probe])
             .output()
         {
             if out.status.success() {
+                let dump = String::from_utf8_lossy(&out.stdout);
                 // Shell bookkeeping vars that must NOT be imported into a
                 // GUI process context (PATH is handled with its own guard).
                 const SKIP: &[&str] = &["PATH", "PWD", "OLDPWD", "SHLVL", "_"];
-                for (name, value) in parse_env_dump(&String::from_utf8_lossy(&out.stdout)) {
+                for (name, value) in parse_env_dump(&dump) {
                     if name == "PATH" {
                         // Sanity guard: a real PATH always contains ':'. If
                         // the shell rc errored out and we got garbage /
@@ -214,21 +223,37 @@ fn main() -> Result<()> {
     server::start_ui(pending_launch)
 }
 
-/// Parse `env` command output into (name, value) pairs for the login-shell
-/// environment inheritance probe in `main()`.
-///
-/// `env` prints one `NAME=value` per line, but two real-world wrinkles:
-///   - Interactive rc files sometimes echo junk to stdout (greeting
-///     banners, `echo` in .zshrc). Those lines are ignored until the first
-///     valid entry appears.
-///   - Values can contain newlines (multiline exports). A line that does
-///     NOT start a new entry is treated as a continuation of the previous
-///     variable's value.
-///
-/// An entry line must match `^[A-Za-z_][A-Za-z0-9_]*=`. Split at the first
-/// '=' — values may themselves contain '=' (base64 blobs, `a=b` pairs).
+/// Sentinel printed by the login-shell probe before `env` output. The probe
+/// is `printf 'MARKER\n'; env`. rc-file echo that lands BEFORE the marker is
+/// irrelevant; echo AFTER the marker can't be told apart from a multiline
+/// value, so we keep the LAST marker and parse only what follows it.
 #[cfg(not(target_os = "windows"))]
-fn parse_env_dump(dump: &str) -> Vec<(String, String)> {
+const ENV_DUMP_MARKER: &str = "__COFFEE_ENV_DUMP_MARKER__";
+
+/// Parse raw probe stdout into (name, value) pairs.
+///
+/// The probe prints `ENV_DUMP_MARKER` then `env`. We slice from the LAST
+/// marker so trailing rc echo can't extend the final variable's value
+/// (the leading-echo case is handled by `is_entry_start` rejecting non-entry
+/// lines before the first valid entry). If the marker is absent (shell
+/// without `printf`), we fall back to parsing the whole dump.
+#[cfg(not(target_os = "windows"))]
+fn parse_env_dump(raw: &str) -> Vec<(String, String)> {
+    let env_only = match raw.rfind(ENV_DUMP_MARKER) {
+        Some(idx) => &raw[idx + ENV_DUMP_MARKER.len()..],
+        None => raw,
+    };
+    parse_env_lines(env_only)
+}
+
+/// Parse marker-sliced `env` output into (name, value) pairs.
+///
+/// An entry line must match `^[A-Za-z_][A-Za-z0-9_]*=`; a line that does
+/// NOT start a new entry is treated as a continuation of the previous
+/// variable's value (multiline exports). Split at the first '=' so values
+/// may themselves contain '=' (base64 blobs, `a=b` pairs).
+#[cfg(not(target_os = "windows"))]
+fn parse_env_lines(env_only: &str) -> Vec<(String, String)> {
     fn is_entry_start(line: &str) -> bool {
         let bytes = line.as_bytes();
         if bytes.is_empty() {
@@ -246,7 +271,7 @@ fn parse_env_dump(dump: &str) -> Vec<(String, String)> {
     }
 
     let mut out: Vec<(String, String)> = Vec::new();
-    for line in dump.lines() {
+    for line in env_only.lines() {
         if is_entry_start(line) {
             let eq = line.find('=').unwrap();
             out.push((line[..eq].to_string(), line[eq + 1..].to_string()));
@@ -260,14 +285,13 @@ fn parse_env_dump(dump: &str) -> Vec<(String, String)> {
 
 #[cfg(all(test, not(target_os = "windows")))]
 mod env_parse_tests {
-    use super::parse_env_dump;
+    use super::{parse_env_dump, parse_env_lines, ENV_DUMP_MARKER};
 
     #[test]
     fn parses_simple_entries() {
-        let dump = "PATH=/usr/bin:/bin\nKIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL=1\nHOME=/Users/x\n";
-        let vars = parse_env_dump(dump);
+        let dump = format!("{}\nPATH=/usr/bin:/bin\nKIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL=1\nHOME=/Users/x\n", ENV_DUMP_MARKER);
         assert_eq!(
-            vars,
+            parse_env_dump(&dump),
             vec![
                 ("PATH".to_string(), "/usr/bin:/bin".to_string()),
                 ("KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL".to_string(), "1".to_string()),
@@ -278,18 +302,19 @@ mod env_parse_tests {
 
     #[test]
     fn value_may_contain_equals_sign() {
-        let dump = "TOKEN=abc=def==\n";
+        let dump = format!("{}\nTOKEN=abc=def==\n", ENV_DUMP_MARKER);
         assert_eq!(
-            parse_env_dump(dump),
+            parse_env_dump(&dump),
             vec![("TOKEN".to_string(), "abc=def==".to_string())]
         );
     }
 
     #[test]
     fn rc_echo_junk_before_first_entry_is_ignored() {
-        let dump = "Welcome to my shell!\n\x1b[36mhello\x1b[0m\nFOO=bar\n";
+        // Pre-marker junk: parse_env_dump slices past the last marker.
+        let dump = format!("Welcome to my shell!\n{}\nFOO=bar\n", ENV_DUMP_MARKER);
         assert_eq!(
-            parse_env_dump(dump),
+            parse_env_dump(&dump),
             vec![("FOO".to_string(), "bar".to_string())]
         );
     }
@@ -298,7 +323,7 @@ mod env_parse_tests {
     fn non_entry_lines_extend_multiline_values() {
         let dump = "MULTI=line1\nline2\nline3\nNEXT=ok\n";
         assert_eq!(
-            parse_env_dump(dump),
+            parse_env_lines(dump),
             vec![
                 ("MULTI".to_string(), "line1\nline2\nline3".to_string()),
                 ("NEXT".to_string(), "ok".to_string()),
@@ -313,17 +338,28 @@ mod env_parse_tests {
         // prior entry to extend, those lines are dropped entirely.
         let dump = "1BAD=x\n-BAD=y\nBASH_FUNC_foo%%=() { :; }\nGOOD=1\n";
         assert_eq!(
-            parse_env_dump(dump),
+            parse_env_lines(dump),
             vec![("GOOD".to_string(), "1".to_string())]
         );
     }
 
     #[test]
-    fn malformed_lines_without_prior_entry_are_dropped() {
+    fn garbage_without_prior_entry_is_dropped() {
         let dump = "garbage\n1BAD=x\nGOOD=1\n";
         assert_eq!(
-            parse_env_dump(dump),
+            parse_env_lines(dump),
             vec![("GOOD".to_string(), "1".to_string())]
+        );
+    }
+
+    #[test]
+    fn rc_echo_looking_like_entry_before_marker_is_ignored() {
+        // rc echo that itself looks like NAME=value must NOT be imported.
+        // Without the marker, the original parser would wrongly import FAKE.
+        let dump = format!("FAKE=notreal\n{}\nREAL=1\n", ENV_DUMP_MARKER);
+        assert_eq!(
+            parse_env_dump(&dump),
+            vec![("REAL".to_string(), "1".to_string())]
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,48 +105,70 @@ fn main() -> Result<()> {
         }
     }
 
-    // ── PATH inheritance fix (macOS / Linux) ────────────────────────────
+    // ── Login-shell environment inheritance (macOS / Linux) ─────────────
     // GUI apps on macOS / Linux launched from Dock / Finder / .desktop
-    // entries get a minimal PATH (typically /usr/bin:/bin:/usr/sbin:/sbin)
-    // — they do NOT source the user's interactive shell rc files. So tools
-    // installed via Homebrew, nvm, volta, asdf, npm-global, cargo, bun,
-    // ~/.local/bin, etc. are invisible to every Command::new() in the
-    // process. Symptom: tool-detection cards stay greyed out even though
-    // `claude` / `codex` / `agy` / `hermes` are clearly installed.
+    // entries get a minimal environment from launchd — they do NOT source
+    // the user's interactive shell rc files. Two consequences we've hit:
+    //   1. PATH is typically /usr/bin:/bin:/usr/sbin:/sbin, so tools
+    //      installed via Homebrew, nvm, volta, asdf, npm-global, cargo,
+    //      bun, ~/.local/bin, etc. are invisible to every Command::new()
+    //      in the process. Symptom: tool-detection cards stay greyed out
+    //      even though `claude` / `codex` / `agy` / `hermes` are clearly
+    //      installed.
+    //   2. Every OTHER variable exported in ~/.zshrc / ~/.bashrc is missing
+    //      too — API keys (OPENAI_API_KEY / ANTHROPIC_API_KEY / KIMI_API_KEY),
+    //      tool feature flags, proxy overrides. AI CLIs then behave
+    //      differently inside Coffee CLI than in Terminal.app: Kimi Code's
+    //      secondary-model experiment stayed disabled in PTY tabs even
+    //      though the user had exported
+    //      KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL=1 in ~/.zshrc — the
+    //      toggle worked in Terminal.app (login shell) but not here.
     //
-    // Fix: ask the user's login shell for its real PATH ONCE at startup
-    // and replace the process PATH. Every downstream subprocess
-    // (tool-detection `which`, PTY spawns, etc.) inherits this and
-    // resolves binaries the same way the user's terminal would.
+    // Fix: ask the user's login shell for its full environment ONCE at
+    // startup via a single `-ilc env` probe. PATH replaces the process
+    // PATH (with a sanity guard); every other variable is imported ONLY
+    // when absent from our process env — the launchd/GUI env always wins,
+    // we just fill gaps. PTY spawns inherit the process env (see the
+    // `std::env::vars()` loop in terminal.rs), so one probe here fixes
+    // every downstream tab and tool-detection `which`.
     //
     // We use `-ilc` (interactive + login) so both .zprofile/.bash_profile
     // AND .zshrc/.bashrc are sourced — matches what the user sees when
-    // they open a fresh terminal window.
+    // they open a fresh terminal window. `env` is an external command, so
+    // fish works too (its exported PATH arrives colon-joined, no special
+    // casing needed).
     #[cfg(not(target_os = "windows"))]
     unsafe {
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
-        let basename = std::path::Path::new(&shell)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("");
-        // fish prints $PATH space-separated, not colon-separated. Use its
-        // string-join builtin to emit the same format as POSIX shells.
-        let cmd_str = if basename == "fish" {
-            "string join : -- $PATH"
-        } else {
-            "printf '%s' \"$PATH\""
-        };
         if let Ok(out) = std::process::Command::new(&shell)
-            .args(["-ilc", cmd_str])
+            .args(["-ilc", "env"])
             .output()
         {
             if out.status.success() {
-                let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                // Sanity guard: a real PATH always contains ':'. If the
-                // shell rc errored out and we got garbage / empty, keep
-                // whatever PATH the OS gave us rather than nuking it.
-                if !path.is_empty() && path.contains(':') {
-                    std::env::set_var("PATH", path);
+                // Shell bookkeeping vars that must NOT be imported into a
+                // GUI process context (PATH is handled with its own guard).
+                const SKIP: &[&str] = &["PATH", "PWD", "OLDPWD", "SHLVL", "_"];
+                for (name, value) in parse_env_dump(&String::from_utf8_lossy(&out.stdout)) {
+                    if name == "PATH" {
+                        // Sanity guard: a real PATH always contains ':'. If
+                        // the shell rc errored out and we got garbage /
+                        // empty, keep whatever PATH the OS gave us rather
+                        // than nuking it.
+                        let path = value.trim();
+                        if !path.is_empty() && path.contains(':') {
+                            std::env::set_var("PATH", path);
+                        }
+                        continue;
+                    }
+                    if SKIP.contains(&name.as_str()) {
+                        continue;
+                    }
+                    // Gap-fill only: a variable the GUI process already has
+                    // (from launchd, `launchctl setenv`, or a direct
+                    // terminal launch) always wins over the rc value.
+                    if std::env::var_os(&name).is_none() {
+                        std::env::set_var(&name, &value);
+                    }
                 }
             }
         }
@@ -190,6 +212,120 @@ fn main() -> Result<()> {
     // Default: launch the GUI. Each tab picks its own CWD at
     // launch time — no initial directory needed.
     server::start_ui(pending_launch)
+}
+
+/// Parse `env` command output into (name, value) pairs for the login-shell
+/// environment inheritance probe in `main()`.
+///
+/// `env` prints one `NAME=value` per line, but two real-world wrinkles:
+///   - Interactive rc files sometimes echo junk to stdout (greeting
+///     banners, `echo` in .zshrc). Those lines are ignored until the first
+///     valid entry appears.
+///   - Values can contain newlines (multiline exports). A line that does
+///     NOT start a new entry is treated as a continuation of the previous
+///     variable's value.
+///
+/// An entry line must match `^[A-Za-z_][A-Za-z0-9_]*=`. Split at the first
+/// '=' — values may themselves contain '=' (base64 blobs, `a=b` pairs).
+#[cfg(not(target_os = "windows"))]
+fn parse_env_dump(dump: &str) -> Vec<(String, String)> {
+    fn is_entry_start(line: &str) -> bool {
+        let bytes = line.as_bytes();
+        if bytes.is_empty() {
+            return false;
+        }
+        let first = bytes[0];
+        if !(first.is_ascii_alphabetic() || first == b'_') {
+            return false;
+        }
+        let name_len = bytes
+            .iter()
+            .take_while(|b| b.is_ascii_alphanumeric() || **b == b'_')
+            .count();
+        bytes.get(name_len) == Some(&b'=')
+    }
+
+    let mut out: Vec<(String, String)> = Vec::new();
+    for line in dump.lines() {
+        if is_entry_start(line) {
+            let eq = line.find('=').unwrap();
+            out.push((line[..eq].to_string(), line[eq + 1..].to_string()));
+        } else if let Some(last) = out.last_mut() {
+            last.1.push('\n');
+            last.1.push_str(line);
+        }
+    }
+    out
+}
+
+#[cfg(all(test, not(target_os = "windows")))]
+mod env_parse_tests {
+    use super::parse_env_dump;
+
+    #[test]
+    fn parses_simple_entries() {
+        let dump = "PATH=/usr/bin:/bin\nKIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL=1\nHOME=/Users/x\n";
+        let vars = parse_env_dump(dump);
+        assert_eq!(
+            vars,
+            vec![
+                ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+                ("KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL".to_string(), "1".to_string()),
+                ("HOME".to_string(), "/Users/x".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn value_may_contain_equals_sign() {
+        let dump = "TOKEN=abc=def==\n";
+        assert_eq!(
+            parse_env_dump(dump),
+            vec![("TOKEN".to_string(), "abc=def==".to_string())]
+        );
+    }
+
+    #[test]
+    fn rc_echo_junk_before_first_entry_is_ignored() {
+        let dump = "Welcome to my shell!\n\x1b[36mhello\x1b[0m\nFOO=bar\n";
+        assert_eq!(
+            parse_env_dump(dump),
+            vec![("FOO".to_string(), "bar".to_string())]
+        );
+    }
+
+    #[test]
+    fn non_entry_lines_extend_multiline_values() {
+        let dump = "MULTI=line1\nline2\nline3\nNEXT=ok\n";
+        assert_eq!(
+            parse_env_dump(dump),
+            vec![
+                ("MULTI".to_string(), "line1\nline2\nline3".to_string()),
+                ("NEXT".to_string(), "ok".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_entry_names() {
+        // Leading digit / dash / percent (bash exported functions look
+        // like `BASH_FUNC_foo%%=...`) must NOT start an entry; with no
+        // prior entry to extend, those lines are dropped entirely.
+        let dump = "1BAD=x\n-BAD=y\nBASH_FUNC_foo%%=() { :; }\nGOOD=1\n";
+        assert_eq!(
+            parse_env_dump(dump),
+            vec![("GOOD".to_string(), "1".to_string())]
+        );
+    }
+
+    #[test]
+    fn malformed_lines_without_prior_entry_are_dropped() {
+        let dump = "garbage\n1BAD=x\nGOOD=1\n";
+        assert_eq!(
+            parse_env_dump(dump),
+            vec![("GOOD".to_string(), "1".to_string())]
+        );
+    }
 }
 
 /// Query the installed WebKit2GTK 4.1 minor version via dlopen +


### PR DESCRIPTION
# fix(env): GUI 启动时完整继承登录 shell 环境，修复 `.zshrc` 导出变量在 PTY 标签页中全部丢失

## 问题现象

在 macOS 上，凡是通过 `.zshrc` / `.bashrc` 导出的环境变量，在 Coffee CLI 的 PTY 标签页里**全部不可见**，导致 AI CLI 在 Coffee CLI 里和在 Terminal.app 里行为不一致。

最初发现这个问题的具体场景：

- 用户在 `~/.zshrc` 中写入 `export KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL=1`（Kimi Code 官方的实验特性开关，见[官方文档](https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/env-vars.html)）；
- 在 macOS 自带 Terminal.app 里运行 `kimi`：实验特性面板中 "Secondary model for subagents" 显示 enabled，`/secondary_model` 可以正常切换模型 ✅；
- 在 Coffee CLI 的 kimi 标签页里：同一个开关显示 disabled，面板上怎么按 Space 都切换不了，`/secondary_model` 也不可用 ❌。

看起来像是 TUI 按键失灵，实际上是**进程环境里根本没有这个变量**。

受影响的不只是这一个开关——这是一整类问题：`.zshrc` 里的 `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `KIMI_API_KEY`、代理设置、各种工具的特性开关，凡是依赖 shell rc 导出的变量，在 Coffee CLI 里全部拿不到。

## 根因分析

macOS 上从 Dock / Finder 启动的 GUI 应用由 launchd 创建，**不会加载用户的 shell rc 文件**（`~/.zshrc` / `~/.zprofile` 等），只能拿到 launchd 的极简环境。这是平台定义行为，与具体机器配置无关。

Coffee CLI 自己其实已经承认并处理过这个问题的一半：`src/main.rs` 里原有的「PATH inheritance fix」注释明确写道：

> GUI apps on macOS / Linux launched from Dock / Finder / .desktop entries get a minimal PATH — they do NOT source the user's interactive shell rc files.

但该修复**只把 login shell 的 PATH 补进了进程环境，其他变量全部丢弃**。而 `src/terminal.rs` 的 PTY spawn 是整体继承 Coffee CLI 进程环境（`std::env::vars()` 循环）的——所以进程环境里缺什么，每个标签页里的 AI CLI 就缺什么。

因果链：

```
~/.zshrc 导出 VAR=1
   ├─ Terminal.app（login shell）→ 加载 .zshrc → kimi 读到 VAR=1 ✅
   └─ Coffee CLI（launchd）→ 不读 .zshrc
        └─ main.rs 原 PATH 修复：只从 login shell 取 PATH，丢弃其他变量
             └─ terminal.rs spawn 继承进程环境 → kimi 读不到 VAR ❌
```

## 为什么确定是 Coffee CLI 的 bug，而不是用户机器配置问题

差分证据链（同一台机器、同一个用户、同一个 kimi 二进制、同一份 `.zshrc`）：

1. **kimi 侧没问题**：Terminal.app 里开关正常、`/secondary_model` 可用；
2. **shell 配置没问题**：`/bin/zsh -ilc env` 能输出 `KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL=1`（本 PR 修复后正是用这同一个探针取环境）；
3. **变量只在 Coffee CLI 启动的进程里缺失**：在 Coffee CLI 的 kimi 会话里直接执行 `env`，输出中有 `COFFEE_CLI_TOOL=kimicode`（证明确实是 Coffee CLI spawn 的进程），但没有 `KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL`；
4. **不依赖任何本机特殊配置**：任意一台 macOS 机器，只要在 `.zshrc` 里 export 任意变量、从 Dock 启动 Coffee CLI，都能 100% 复现；Linux 的 `.desktop` 启动同理（代码里 `#[cfg(not(target_os = "windows"))]` 的 PATH 修复就是为这两个平台写的）；
5. **代码路径闭合**：`main.rs`（只补 PATH）→ `terminal.rs`（继承进程环境）→ PTY 子进程，缺环就在 `main.rs`。

## 复现步骤

1. 在 `~/.zshrc` 加一行：`export COFFEE_REPRO_TEST=hello`；
2. 从 Dock / Finder 启动 Coffee CLI，打开任意一个 shell 标签页；
3. 执行 `echo $COFFEE_REPRO_TEST` → **空**（bug）；
4. 对照：打开 Terminal.app 执行同一命令 → 输出 `hello`。

## 修复方案

把 `main.rs` 启动时的探针从「只取 PATH」改为「取完整登录环境」：

- 探针命令由 `$SHELL -ilc 'printf $PATH'` 改为 `$SHELL -ilc env`，**一次 spawn 拿到全部变量**（不增加启动开销；`env` 是外部命令，fish 也能跑，原来 fish 的 `string join` 特判随之删除——fish 导出的 PATH 在外部命令视角下本来就是冒号分隔的）；
- `PATH` 沿用原有 sanity guard（非空且含 `:` 才替换进程 PATH），语义完全不变；
- 其余变量 **gap-fill**：只补充进程环境里**不存在**的变量——launchd 自带的环境、`launchctl setenv` 设置的、从终端里直接启动二进制继承的环境，一律优先，不会被 rc 里的值覆盖；
- 跳过 shell 簿记变量：`PATH`（单独处理）、`PWD` / `OLDPWD` / `SHLVL` / `_`——这些是 shell 会话内部状态，搬进 GUI 进程是错的；
- 新增纯函数 `parse_env_dump` 解析 `env` 输出：条目行须匹配 `^[A-Za-z_][A-Za-z0-9_]*=`（挡掉 rc echo 的杂讯和 bash 导出函数的 `BASH_FUNC_foo%%=` 畸形行），非条目行视为上一个变量的多行值续行，值里允许含 `=`；
- **Windows 不动**：Windows 没有 login shell rc 的概念，现有 registry PATH hydrate（`windows_path.rs`）保持不变。

生效路径：启动时补一次进程环境 → `terminal.rs` spawn 时整体继承 → 所有下游标签页、工具检测 `which` 全部受益，无需改其他任何模块。

## 测试

- 新增 6 个针对 `parse_env_dump` 的单元测试，全部通过：
  - 常规条目解析；
  - 值中含 `=`（base64 等）；
  - rc echo 杂讯（含 ANSI 转义）在首个条目前被忽略；
  - 多行值续行拼接；
  - 畸形变量名（前导数字 / 连字符 / `BASH_FUNC_` 百分号格式）不识别为条目；
  - 无前置条目时垃圾行直接丢弃；
- `cargo check` 绿灯（仅剩 `shell_probe.rs` 一个与本次无关的既有 warning）；
- 真机验证：`/bin/zsh -ilc env` 输出中确认包含目标变量；`cargo tauri build --bundles app` 出包成功。

## 影响面与兼容性

- **受益**：macOS / Linux GUI 启动的所有用户——`.zshrc` / `.bashrc` 里的 API key、工具开关、代理变量从此在 Coffee CLI 里可用，AI CLI 行为与 Terminal.app 对齐；
- **行为变化**：仅「补缺失变量」，不覆盖任何已有环境变量；PATH 处理逻辑逐字保留；
- **风险**：与原 PATH 修复相同——依赖 `$SHELL -ilc` 能成功执行（原修复已在线上验证该前提）；用户 rc 里 echo 的文本会被解析器挡掉或并入上一个多行值，不会形成垃圾变量名；
- **回退**：revert 本 commit 即恢复原行为，无状态迁移。

## 验证修复后的效果

替换构建产物重启 Coffee CLI 后，kimi 标签页的实验特性面板中 "Secondary model for subagents" 直接显示 enabled，`/secondary_model` 可正常切换——与 Terminal.app 行为一致。
