### PR TITLE
fix(terminal): drop right-click mouse events so Claude Code doesn't double-paste

### DIFF
--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -863,11 +863,31 @@ function TierTerminalImpl({
 
     // Forward keyboard input to Rust PTY backend.
     //
+    // Strip right-button mouse press/release before the PTY ever sees them.
+    // Coffee CLI owns right-click itself (custom context menu: Copy / Paste /
+    // Select All), but xterm still forwards the button events to the PTY
+    // whenever the TUI has mouse reporting on. Claude Code ≥v2.1.143 acts on
+    // that right-click by pasting the clipboard ITSELF — so the user got one
+    // paste from the TUI plus a second from our menu item (upstream:
+    // anthropics/claude-code#61035). Other tools (Kimi/Codex/OpenCode) don't
+    // bind right-click, which is why only Claude Code duplicated. Dropping
+    // the events here leaves our menu as the single right-click paste path.
+    // SGR encoding only (`\x1b[<b;x;yM` press / `\x1b[<b;x;ym` release);
+    // motion (bit 5) and wheel (bit 6) events are left untouched.
+    const stripRightClickMouse = (data: string): string => {
+      if (!data.includes('\x1b[<')) return data;
+      return data.replace(/\x1b\[<(\d+);\d+;\d+[Mm]/g, (seq, b) => {
+        const btn = Number(b);
+        return (btn & 3) === 2 && !(btn & 96) ? '' : seq;
+      });
+    };
     // Single entry point for user-typed data on its way to the PTY. term.onData
     // covers xterm's own key handling; the macOS IME symbol-passthrough input
     // listener below calls the same function for IME-committed text that
     // xterm drops (issue #107, WKWebView commit-first ordering).
-    const forwardInput = (data: string) => {
+    const forwardInput = (rawData: string) => {
+      const data = stripRightClickMouse(rawData);
+      if (!data) return;
       if (data.includes('\r') || data.includes('\n')) {
         markNotifySoundPromptSubmitted(sessionId, tool);
       }


### PR DESCRIPTION
## Problem

Right-click copy → right-click paste inside a Claude Code session inserts the clipboard content **twice**. Other tools (Kimi Code, Codex, OpenCode, raw shells) are unaffected.

## Root cause

Since **v2.1.143**, Claude Code enables mouse reporting and reacts to right-click by pasting the clipboard itself — an upstream regression tracked at [anthropics/claude-code#61035](https://github.com/anthropics/claude-code/issues/61035) (also reproducible in VS Code's integrated terminal, no Coffee CLI code involved).

So a single right-click paste in Coffee CLI had **two** consumers:

1. xterm forwards the right-button press/release to the PTY (mouse reporting is on) → Claude Code pastes once on its own;
2. the user picks **Paste** in Coffee CLI's custom context menu → `term.paste()` pastes again.

Ctrl+V is unaffected (it goes through `preventDefault` + a single manual paste), and tools that don't capture the mouse never see the button events — which is why only Claude Code duplicated.

## Fix

Strip SGR right-button press/release sequences (`ESC[<b;x;yM` / `ESC[<b;x;ym`, button bits == 2, incl. Shift/Ctrl/Alt modifiers) in `forwardInput`, the single entry point for user input on its way to the PTY. Coffee CLI already owns right-click with its own context menu (`onContextMenu` → `preventDefault`), so forwarding those events to the TUI serves no purpose — the menu stays the single paste path.

Left/middle buttons, wheel (bit 6), and drag-motion (bit 5) events are passed through untouched, so scrolling and any other mouse interactions are unaffected.

This is a defensive fix that stays correct even after Anthropic patches the upstream regression: right-click is exclusively owned by the app-level menu either way, nothing to revert.

## Verification

- `tsc -b && vite build` green
- Filter logic exercised against 12 cases (right press/release with and without modifiers stripped; left/middle/wheel/motion/bracketed-paste payloads untouched)
- Manual end-to-end test in `tauri dev`: right-click copy → right-click paste in a Claude Code session now inserts exactly once; wheel scroll and Ctrl+V unchanged