### PR TITLE
fix(titlebar): add tooltip to settings gear for discoverability

### DIFF
--- a/src-ui/src/components/common/TitleBar.tsx
+++ b/src-ui/src/components/common/TitleBar.tsx
@@ -12,11 +12,13 @@
 import { commands, isTauri } from '../../tauri';
 import { useAppState, useAppDispatch, schemeLabels } from '../../store/app-state';
 import { IS_MACOS } from '../../lib/platform';
+import { useT } from '../../i18n/useT';
 import './TitleBar.css';
 
 export function TitleBar() {
   const { state } = useAppState();
   const dispatch = useAppDispatch();
+  const t = useT();
 
   // The active scheme's three combos, shown as persistent hints on the left /
   // Gambit / right buttons — a deliberate memory hook for the product's
@@ -185,11 +187,15 @@ export function TitleBar() {
         )}
 
         {/* Personalization settings — gear opens the consolidated modal that
-            replaced the old left-panel theme/language popovers. */}
+            replaced the old left-panel theme/language popovers. The `title`
+            tooltip matters here: new users reported not finding settings
+            because the gear sits unlabeled among the look-alike layout
+            toggles (those at least carry hotkey-hint text). */}
         <button
           className={`titlebar-btn titlebar-btn--layout${state.settingsOpen ? ' is-active' : ''}`}
           onClick={() => dispatch({ type: 'TOGGLE_SETTINGS' })}
-          aria-label="Settings"
+          aria-label={t('settings.title')}
+          title={t('settings.title')}
           aria-pressed={state.settingsOpen}
         >
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">


### PR DESCRIPTION
## Problem

Several new users reported they could not find the settings page.

Root cause: the settings gear button in the titlebar only had an `aria-label` (no `title` tooltip, so hovering shows nothing), and it shares the same `titlebar-btn--layout` styling as the adjacent panel toggles — it visually blends into the layout-toggle group and goes unrecognized.

## Fix

- Add a `title` tooltip to the gear button, using the existing i18n `settings.title` key (already translated in all 11 locales)
- Switch the hardcoded English `aria-label="Settings"` to the same i18n key

One-line UX fix, no behavior change. `npm run build` passes.