### PR TITLE
fix(terminal): stop the macOS IME passthrough double-sending Space and capitals

### DIFF
--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -766,8 +766,9 @@ function TierTerminalImpl({
       // modifyOtherKeys):
       //   a. A capture-phase `input` listener on the container (wired just
       //      below) forwards exactly the commits xterm will NOT deliver — the
-      //      complementary case to xterm's condition, i.e.
-      //      `ev.composed && keyDownSeen` — then stopPropagation (xterm's
+      //      complementary case to xterm's conditions, i.e.
+      //      `ev.composed && keyDownSeen && !keyPressHandled` (issue #128 for
+      //      the last term) — then stopPropagation (xterm's
       //      textarea-capture listener is a descendant target, so this prevents
       //      its double-delivery) and clears the textarea so a later 229-diff
       //      can't re-send stale text. The 229-first Chromium ordering is left
@@ -783,6 +784,7 @@ function TierTerminalImpl({
       const ime = isMac && !__IS_LINUX__
         ? {
             keyDownSeen: false,        // mirror of xterm `_keyDownSeen`
+            keyPressHandled: false,    // mirror of xterm `_keyPressHandled` (issue #128)
             last229At: 0,             // Chromium: 229 BEFORE commit → xterm owns it
             lastNonAsciiCommitAt: 0,  // window for the caret-key swallow
             lastCompositionEndAt: 0,  // guard so a composition's final commit
@@ -795,10 +797,11 @@ function TierTerminalImpl({
       // Companion to the keydown bookkeeping + caret-swallow in
       // attachCustomKeyEventHandler above. An IME commit arrives as a plain
       // `input` event on the helper textarea (inputType 'insertText').
-      // xterm delivers it only when `(!ev.composed || !_keyDownSeen)`
-      // (CoreBrowserTerminal.ts:1196); we forward exactly the complementary
-      // case (`ev.composed && keyDownSeen`) — the commits xterm drops on
-      // WKWebView's commit-first flow. Registered CAPTURE-phase on the
+      // xterm delivers it only when `(!ev.composed || !_keyDownSeen)` and
+      // `!_keyPressHandled` (CoreBrowserTerminal.ts:1196-1199); we forward
+      // exactly the complementary case (`ev.composed && keyDownSeen &&
+      // !keyPressHandled`) — the commits xterm drops on WKWebView's
+      // commit-first flow. Registered CAPTURE-phase on the
       // container (an ancestor of the textarea) so it runs BEFORE xterm's
       // own capture listener on the textarea; stopPropagation then prevents
       // xterm's listener from double-delivering, and clearing the textarea
@@ -830,6 +833,17 @@ function TierTerminalImpl({
             // Mirror of xterm's delivery condition `(!ev.composed ||
             // !_keyDownSeen)`: only forward when xterm will NOT.
             if (!ie.composed || !ime.keyDownSeen) return;
+            // Mirror of xterm's second guard, `if (this._keyPressHandled)
+            // return` (CoreBrowserTerminal.ts:1197). The character already went
+            // to the PTY via xterm's keypress path; this `input` is just the
+            // browser inserting it into the helper textarea afterwards, because
+            // `_keyPress` never preventDefaults (its `cancel(ev)` is a no-op
+            // under the default `cancelEvents: false`). Only two printable keys
+            // travel that path — Space (keyCode 32 fails evaluateKeyboardEvent's
+            // `keyCode >= 48` keydown test) and capital letters (xterm's
+            // caps-lock IME hack defers A–Z to keypress) — and forwarding them
+            // again was the "hello  " double space of issue #128.
+            if (ime.keyPressHandled) return;
             forwardInput(ie.data);
             ev.stopPropagation();
             imeTextarea.value = '';
@@ -929,19 +943,28 @@ function TierTerminalImpl({
     // `ime` (declared above, next to the macOS input listener) mirrors
     // xterm's private `_keyDownSeen` (set on keydown, cleared on keyup —
     // both fire `attachCustomKeyEventHandler` per CoreBrowserTerminal.ts:1025
-    // and :1122). Coupling is intentional and documented; pin against this
-    // xterm version on upgrade.
+    // and :1122) and `_keyPressHandled` (set when `_keyPress` delivers,
+    // :1149-1177; cleared on keyup, :1131). Coupling is intentional and
+    // documented; pin against this xterm version on upgrade.
 
     // Handle native Copy/Paste shortcuts
     term.attachCustomKeyEventHandler((e) => {
-      // macOS IME bookkeeping (issue #107) — mirror xterm's `_keyDownSeen` and
-      // record the Chromium-style 229 ordering for the commit listener.
+      // macOS IME bookkeeping (issues #107, #128) — mirror xterm's
+      // `_keyDownSeen` / `_keyPressHandled` and record the Chromium-style 229
+      // ordering for the commit listener.
       if (ime) {
         if (e.type === 'keydown') {
           ime.keyDownSeen = true;
           if (e.keyCode === 229) ime.last229At = performance.now();
+        } else if (e.type === 'keypress') {
+          // xterm's `_keyPress` delivers a keypress that carries a char code
+          // unless Ctrl/Alt/Meta is held (Option alone is a third-level shift
+          // on macOS while macOptionIsMeta is off, CoreBrowserTerminal.ts:1105).
+          const thirdLevelShift = e.altKey && !e.ctrlKey && !e.metaKey && !term.options.macOptionIsMeta;
+          ime.keyPressHandled = !!e.charCode && (!(e.altKey || e.ctrlKey || e.metaKey) || thirdLevelShift);
         } else if (e.type === 'keyup') {
           ime.keyDownSeen = false;
+          ime.keyPressHandled = false;
         }
       }
       if (e.type === 'keydown') {


### PR DESCRIPTION
Closes #128

> **中文摘要**：macOS 终端 tab 里空格（以及 Shift / Caps Lock 打出的大写字母）会被发到 PTY 两次。根因在 #107 的 IME passthrough：它只镜像了 xterm `_inputEvent` 的第一道守卫 `_keyDownSeen`，漏掉了第二道 `_keyPressHandled`。空格和 A–Z 是仅有的走 **keypress** 路径投递的可打印键，而 xterm 的 keypress 处理不做 preventDefault，浏览器随后把同一个字符插进 helper textarea 并触发 `input`，passthrough 就再发了一次。本 PR 按已有的 `_keyDownSeen` 镜像方式补上 `_keyPressHandled` 镜像；改动全部在 macOS-only 块内，Windows / Linux 不受影响。

## Why

On macOS every Space typed into a terminal tab reaches the PTY twice (`hello` + Space → `hello  `), in raw shells and in every agent CLI, with both Chinese and ABC input sources (#128). Capital letters (Shift+letter or Caps Lock) double the same way.

The passthrough added for #107 forwards an `input` event whenever xterm's own delivery condition `(!ev.composed || !_keyDownSeen)` is false. But xterm's `_inputEvent` has a **second** guard the passthrough did not mirror: `if (this._keyPressHandled) return` (`CoreBrowserTerminal.ts:1197`). Two printable keys are delivered through xterm's **keypress** path instead of keydown:

- **Space** — keyCode 32 fails the `keyCode >= 48` test in `evaluateKeyboardEvent`'s default branch (`Keyboard.ts:357`), so keydown returns without sending or cancelling;
- **A–Z** — xterm's caps-lock IME hack defers them to keypress (`CoreBrowserTerminal.ts:1070-1076`).

`_keyPress` sends the character and then calls `this.cancel(ev)`, which is a no-op under the default `cancelEvents: false`, so the browser goes on to insert the same character into the helper textarea and fires `input`. xterm drops that event via `_keyPressHandled`; the passthrough saw `composed && keyDownSeen` and sent it a second time. Every other printable key is sent *and* `preventDefault`ed on keydown, so no `input` follows — which is why only Space (and capitals) doubled.

Event trace for `ab cd` with the v3.4.8 logic (Playwright WebKit 26.5, xterm 6.0.0; `out` = bytes handed to the PTY):

```
keydown     key=" " keyCode=32                 prevented=false  out="ab"
keypress    key=" " charCode=32                prevented=false  out="ab "    <- xterm's keypress path sent it
beforeinput data=" "                                            out="ab "
(input: swallowed by the passthrough after forwarding)
keyup       key=" "                                             out="ab  "   <- second space
```

## What

Mirror `_keyPressHandled` the same way `_keyDownSeen` is already mirrored, inside the existing macOS-only block:

- `attachCustomKeyEventHandler`: on `keypress`, set `ime.keyPressHandled` when xterm's `_keyPress` will deliver (char code present and no Ctrl/Alt/Meta — Option alone is a third-level shift on macOS while `macOptionIsMeta` is off); clear it on `keyup`, like xterm does.
- `onImeCommitInput`: skip the forward when `ime.keyPressHandled` is set.

IME commits on the WKWebView commit-first flow never produce a keypress, so they are still forwarded exactly as before. I chose this over the ASCII guard sketched in the issue because it fixes the mechanism rather than one symptom: an ASCII-only guard would leave `HH` and Option-key third-level characters (also keypress-delivered, non-ASCII) doubling, and it would drop any half-width commit an IME delivers on the commit-first flow. Windows and Linux are untouched — the whole passthrough is gated on `isMac && !__IS_LINUX__`.

## Verification

Playwright driving stock xterm 6.0.0 with real key events against a copy of the passthrough + key-handler logic, `variant=current` (v3.4.8) vs `variant=fixed` (this PR). Identical results on **WebKit 26.5** (Playwright v2311) and **Chromium**:

| scenario | v3.4.8 | this PR |
|---|---|---|
| `hello` | `hello` | `hello` |
| `ab cd` (#128) | **`ab  cd`** | `ab cd` |
| Shift+H, `i` | **`HHi`** | `Hi` |
| `1!x=` | `1!x=` | `1!x=` |
| Enter | `\r` | `\r` |
| commit-first IME `（` (#107) | `（` | `（` |
| commit-first `？` then ` x` | `？ x` | `？ x` |
| pair commit `（）` + synthesized ArrowLeft | `（）`, arrow swallowed | `（）`, arrow swallowed |
| bare ArrowLeft | `ESC[D` | `ESC[D` |

The commit-first flow is simulated (an `insertText` `input` event dispatched on the helper textarea while Shift is held, followed by a keyCode-229 keydown) since Playwright cannot drive a real IME. Happy to share the harness if useful.

- `cd src-ui && npm run build` (`tsc -b && vite build`) green; eslint clean on the file.
- `cargo check` green (Rust untouched; note the bare command on macOS needs the `macos-private-api` feature that `cargo tauri` adds on its own).
- Not yet re-checked inside the shipped WKWebView build: the single-instance plugin stopped me from launching a second instance next to my running session. The `od -c` recipe from #128 is the quickest confirmation on a real build — in a terminal tab run `od -c`, type `ab`, Space, `cd`, Enter, Ctrl+D, and check there is exactly one space byte between `b` and `c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
