### PR TITLE
fix(terminal): survive the birth-time fit race that seeded a 10-column grid

### DIFF
--- a/src-ui/src/components/center/TierTerminal.tsx
+++ b/src-ui/src/components/center/TierTerminal.tsx
@@ -1474,8 +1474,17 @@ function TierTerminalImpl({
       // All listeners registered — NOW start the PTY process
       if (!mounted) return;
 
-      const initialCols = term.cols || 80;
-      const initialRows = term.rows || 24;
+      // A fit that ran during the birth layout storm (launch session restore,
+      // panel slide, gambit dock mount) can seed an absurd grid — 10×40 was
+      // captured in the wild on 2026-09-07, with the PTY spawned at that size
+      // so pi/Claude painted a 10-column screen they only ever repaint on the
+      // next resize. Spawning at the classic 80×24 instead costs one extra
+      // resize when the real size differs, and the post-spawn fit below sends
+      // it within two frames. Threshold 20 cols is below any pane a split can
+      // produce on a sane window, so it never misfires on genuinely narrow
+      // terminals.
+      const initialCols = term.cols >= 20 ? term.cols : 80;
+      const initialRows = term.rows >= 6 ? term.rows : 24;
 
         try {
           await commands.tierTerminalStart(sessionId, tool, initialCols, initialRows, theme, lang, toolData, folderPath ?? undefined, resumeToken, appStateRef.current.defaultShell);
@@ -1993,6 +2002,31 @@ function TierTerminalImpl({
     const dismiss = () => {
       if (dismissed) return;
       dismissed = true;
+      // Birth-time fit verification, run at the exact moment the splash
+      // reveals the terminal. Every fit before this point (open-time fit,
+      // post-spawn double-rAF fit, ResizeObserver trailing fit) can land
+      // mid-layout-storm and seed a collapsed grid — 10×40 observed on
+      // 2026-09-07 — and if the geometry settles before the next observer
+      // fire, that seed STICKS: the terminal is revealed at 10 columns and
+      // only a manual tab switch corrects it. By dismissal the branding
+      // window (≥800 ms) plus the tool's first frame have elapsed, so the
+      // container has reached its final size; one verified fit here is
+      // RO-independent and heals the seed before the content is ever seen.
+      // Hidden tabs are skipped (fit would read zero) — the activation
+      // effect owns their first reveal.
+      try {
+        const t = xtermRef.current;
+        if (t && termRef.current && termRef.current.offsetParent !== null && fitRef.current) {
+          fitRef.current.fit();
+          if (t.cols > 0 && t.rows > 0) {
+            const previous = lastResizeRef.current;
+            if (!previous || previous.cols !== t.cols || previous.rows !== t.rows) {
+              lastResizeRef.current = { cols: t.cols, rows: t.rows };
+              commands.tierTerminalResize(sessionId, t.cols, t.rows).catch(() => {});
+            }
+          }
+        }
+      } catch { /* Best-effort verification; failure is non-fatal. */ }
       setSplashFading(true);
       // 300 ms fade-out (was 600). The splash is dismissed quickly
       // now that we trigger on first real output, so the underlying


### PR DESCRIPTION
## Symptom

Since today's v3.5.0 cold start, terminals opened at a ~10-column collapsed grid: pi's status line read `10 · 10`, banners wrapped mid-word, and a multi-agent pane showed only a "Jump to ..." fragment at the top-left. The state stuck until a manual tab switch.

## Root cause

A terminal born during a layout storm (launch session restore, panel slide, gambit dock mount) can have its first `fit()` land while the container is still ~110px wide. That seeds a 10-column grid **and** the PTY is spawned at that size (`initialCols = term.cols || 80`). When the geometry settles before the next ResizeObserver fire, nothing re-fires: the seed sticks and only the tab-activation refit heals it.

Not a v3.5.0 regression: the v3.4.9→v3.5.0 frontend delta touches only `history-cache.ts`, and the backend resize dedupe was verified against portable-pty 0.9 (`ConPTY::get_size` returns the last successfully applied size, so it cannot suppress a needed resize). Updating the app merely triggered the cold start that exposed the pre-existing race.

## Fix

Two gates in `TierTerminal.tsx`:

1. **Spawn clamp** — `initialCols/initialRows` below 20/6 fall back to the classic 80×24. TUIs no longer start at an absurd size; the existing post-spawn fit + resize corrects within two frames.
2. **Dismissal verification** — when the splash dismisses (branding window elapsed, tool's first frame painted), run one final fit + resize that is independent of the ResizeObserver. By then the container has its final size, so a storm-seeded grid is healed before the content is ever shown. Hidden tabs skip it; the activation effect owns their first reveal.

## Test plan

- [x] `cd src-ui && npm run build` green
- [ ] Cold start with session restore (the repro window): new/restored conversations should never render collapsed; if one does, capture it — that would point at a third fit path worth a permanent drift audit.